### PR TITLE
Modify datetime enums

### DIFF
--- a/sous-chef/sous_chef/abstract/extended_enum.py
+++ b/sous-chef/sous_chef/abstract/extended_enum.py
@@ -17,6 +17,15 @@ def extend_enum(inherited_enums: List):
 
 class ExtendedEnum(Enum):
     @classmethod
+    def _missing_(cls, value):
+        if isinstance(value, str):
+            value_lower = value.lower()
+            for member in cls:
+                if member.name.lower() == value_lower:
+                    return member
+        return None
+
+    @classmethod
     def name_list(cls, string_method: str = "casefold"):
         return list(map(lambda c: getattr(c.name, string_method)(), cls))
 

--- a/sous-chef/sous_chef/date/get_due_date.py
+++ b/sous-chef/sous_chef/date/get_due_date.py
@@ -5,8 +5,9 @@ from omegaconf import DictConfig
 from pytz import timezone
 from sous_chef.abstract.extended_enum import ExtendedEnum, ExtendedIntEnum
 
+DEFAULT_TIMEZONE = timezone("UTC")
 
-# TODO make configurable?
+
 class Weekday(ExtendedIntEnum):
     monday = 0
     tuesday = 1
@@ -21,19 +22,17 @@ def get_weekday_index(weekday: str) -> int:
     return Weekday[weekday.casefold()]
 
 
-# TODO make configurable?
 class MealTime(ExtendedEnum):
-    breakfast = {"hour": 8, "minute": 30}
-    lunch = {"hour": 12, "minute": 00}
-    snack = {"hour": 15, "minute": 00}
-    dinner = {"hour": 16, "minute": 30}
-    dessert = {"hour": 19, "minute": 30}
+    breakfast = datetime.time(hour=8, minute=30, tzinfo=DEFAULT_TIMEZONE)
+    lunch = datetime.time(hour=12, minute=0, tzinfo=DEFAULT_TIMEZONE)
+    snack = datetime.time(hour=15, minute=0, tzinfo=DEFAULT_TIMEZONE)
+    dinner = datetime.time(hour=16, minute=30, tzinfo=DEFAULT_TIMEZONE)
+    dessert = datetime.time(hour=19, minute=30, tzinfo=DEFAULT_TIMEZONE)
 
 
 @dataclass
 class DueDatetimeFormatter:
     config: DictConfig
-    meal_time: MealTime = MealTime
     anchor_day: str = field(init=False)
     week_offset: int = field(init=False)
     anchor_datetime: datetime.datetime = None
@@ -70,18 +69,16 @@ class DueDatetimeFormatter:
         return self.replace_time_with_meal_time(due_date, meal_time)
 
     def get_due_datetime_with_time(
-        self, weekday: str, hour: int, minute: int
+        self, weekday: str, time: datetime.time
     ) -> datetime.datetime:
         due_date = self.get_date_relative_to_anchor(weekday=weekday)
-        return self._set_specified_time(
-            due_date=due_date, hour=hour, minute=minute
-        )
+        return self._set_specified_time(due_date=due_date, meal_time=time)
 
     def replace_time_with_meal_time(
         self, due_date: datetime.datetime, meal_time: str
     ) -> datetime.datetime:
-        hour, minute = self._get_meal_time_hour_minute(meal_time)
-        return self._set_specified_time(due_date, hour, minute)
+        meal_time = self._get_meal_time(meal_time)
+        return self._set_specified_time(due_date, meal_time)
 
     def _get_anchor_date_at_midnight(self) -> datetime.datetime:
         weekday_index = get_weekday_index(self.anchor_day)
@@ -104,15 +101,15 @@ class DueDatetimeFormatter:
             days=weekday_index - today_index + self.week_offset * 7
         )
         return datetime.datetime.combine(
-            anchor_date, datetime.datetime.min.time(), tzinfo=timezone("UTC")
+            anchor_date, datetime.datetime.min.time(), tzinfo=DEFAULT_TIMEZONE
         )
 
-    def _get_meal_time_hour_minute(self, meal_time: str) -> (str, str):
-        meal_time_dict = self.meal_time[meal_time.casefold()].value
-        return meal_time_dict["hour"], meal_time_dict["minute"]
+    @staticmethod
+    def _get_meal_time(meal_time: str) -> datetime.time:
+        return MealTime[meal_time.casefold()].value
 
     @staticmethod
     def _set_specified_time(
-        due_date: datetime.datetime, hour: int, minute: int
+        due_date: datetime.datetime, meal_time: datetime.time
     ) -> datetime.datetime:
-        return due_date.replace(hour=hour, minute=minute, second=0)
+        return due_date.combine(date=due_date, time=meal_time)

--- a/sous-chef/sous_chef/date/get_due_date.py
+++ b/sous-chef/sous_chef/date/get_due_date.py
@@ -35,9 +35,23 @@ class Weekday(ExtendedEnum):
                 return member
         return None
 
+    @property
+    def index(self) -> int:
+        return self.value.index
+
+    @property
+    def is_workday(self) -> bool:
+        return self.value.workday
+
+    @property
+    def day_type(self) -> str:
+        if self.is_workday:
+            return "workday"
+        return "weekend"
+
 
 def get_weekday_index(weekday: str) -> int:
-    return Weekday(weekday).value.index
+    return Weekday(weekday).index
 
 
 class MealTime(ExtendedEnum):

--- a/sous-chef/sous_chef/date/get_due_date.py
+++ b/sous-chef/sous_chef/date/get_due_date.py
@@ -17,9 +17,9 @@ class Day(NamedTuple):
 
 class Weekday(ExtendedEnum):
     monday = Day(index=0, workday=True, abbreviation="mon")
-    tuesday = Day(index=1, workday=True, abbreviation="tue")
+    tuesday = Day(index=1, workday=True, abbreviation="tues")
     wednesday = Day(index=2, workday=True, abbreviation="wed")
-    thursday = Day(index=3, workday=True, abbreviation="thur")
+    thursday = Day(index=3, workday=True, abbreviation="thu")
     friday = Day(index=4, workday=True, abbreviation="fri")
     saturday = Day(index=5, workday=False, abbreviation="sat")
     sunday = Day(index=6, workday=False, abbreviation="sun")
@@ -27,6 +27,13 @@ class Weekday(ExtendedEnum):
     @classmethod
     def indices(cls) -> Tuple[int]:
         return tuple(member.value.index for member in cls)
+
+    @classmethod
+    def get_by_abbreviation(cls, abbreviation: str) -> Union["Weekday", None]:
+        for member in cls:
+            if abbreviation.lower() == member.value.abbreviation:
+                return member
+        return None
 
     @classmethod
     def get_by_index(cls, index: int) -> Union["Weekday", None]:

--- a/sous-chef/sous_chef/grocery_list/generate_grocery_list/generate_grocery_list.py
+++ b/sous-chef/sous_chef/grocery_list/generate_grocery_list/generate_grocery_list.py
@@ -317,7 +317,7 @@ class GroceryList:
             meal_time = MealTime[meal_times[int(meal_time)]].value
 
             return self.due_date_formatter.get_due_datetime_with_time(
-                weekday=day, hour=meal_time["hour"], minute=meal_time["minute"]
+                weekday=day, time=meal_time
             )
 
         def _give_referenced_recipe_details():

--- a/sous-chef/sous_chef/grocery_list/generate_grocery_list/generate_grocery_list.py
+++ b/sous-chef/sous_chef/grocery_list/generate_grocery_list/generate_grocery_list.py
@@ -1,8 +1,7 @@
 from dataclasses import dataclass, field
 from datetime import date, datetime, timedelta
-from enum import Enum
 from itertools import chain
-from typing import List, Tuple
+from typing import List, Tuple, Type
 
 import pandas as pd
 from omegaconf import DictConfig
@@ -284,8 +283,8 @@ class GroceryList:
                 response = input(f"\n{text} [y]es, [n]o: ").lower()
             return response
 
-        def _print_enum(eprint: Enum) -> str:
-            return ", ".join(f"{e.name} [{e.value}]" for e in eprint)
+        def _print_week_day_enum(eprint: Type[Weekday]) -> str:
+            return ", ".join(f"{e.name} [{e.value.index}]" for e in eprint)
 
         def _print_list(lprint: list[str]) -> str:
             return ", ".join(
@@ -294,11 +293,16 @@ class GroceryList:
 
         def _get_schedule_day_hour_minute() -> datetime:
             day = None
+            weekday_indices = Weekday.indices()
             while (
-                not day or not day.isnumeric() or int(day) not in iter(Weekday)
+                not day
+                or not day.isnumeric()
+                or int(day) not in weekday_indices
             ):
-                day = input(f"\nWeekday ({_print_enum(Weekday)}): ") or "-1"
-            day = Weekday(int(day)).name.capitalize()
+                day = (
+                    input(f"\nWeekday ({_print_week_day_enum(Weekday)}): ")
+                    or "-1"
+                )
 
             meal_time = None
             meal_times = MealTime.name_list("lower")
@@ -314,10 +318,11 @@ class GroceryList:
                     )
                     or "4"
                 )
-            meal_time = MealTime[meal_times[int(meal_time)]].value
+            meal_time = meal_times[int(meal_time)]
 
             return self.due_date_formatter.get_due_datetime_with_time(
-                weekday=day, time=meal_time
+                weekday=Weekday.get_by_index(int(day)).name,
+                time=MealTime[meal_time].value,
             )
 
         def _give_referenced_recipe_details():

--- a/sous-chef/sous_chef/menu/create_menu/_menu_basic.py
+++ b/sous-chef/sous_chef/menu/create_menu/_menu_basic.py
@@ -468,17 +468,7 @@ def validate_menu_schema(
 
 
 def get_weekday_from_short(short_week_day: str):
-    # TODO move to config
-    day_mapping = {
-        "mon": "Monday",
-        "tue": "Tuesday",
-        "tues": "Tuesday",
-        "wed": "Wednesday",
-        "thu": "Thursday",
-        "fri": "Friday",
-        "sat": "Saturday",
-        "sun": "Sunday",
-    }
-    if short_week_day.lower() in day_mapping:
-        return day_mapping[short_week_day.lower()]
-    raise MenuConfigError(f"{short_week_day} unknown weekday!")
+    weekday = Weekday.get_by_abbreviation(short_week_day)
+    if not weekday:
+        raise MenuConfigError(f"{short_week_day} unknown day!")
+    return weekday.name.capitalize()

--- a/sous-chef/sous_chef/menu/create_menu/_menu_basic.py
+++ b/sous-chef/sous_chef/menu/create_menu/_menu_basic.py
@@ -267,7 +267,7 @@ class MenuBasic(BaseWithExceptionHandling):
 
         if row.override_check == "N" and row.defrost == "N":
             self._check_menu_quality(
-                weekday=row.prep_datetime.weekday(), recipe=recipe
+                weekday_index=row.prep_datetime.weekday(), recipe=recipe
             )
 
         self._inspect_unrated_recipe(recipe)
@@ -281,7 +281,7 @@ class MenuBasic(BaseWithExceptionHandling):
             item=row["item"],
         )
 
-    def _check_menu_quality(self, weekday: int, recipe: pd.Series):
+    def _check_menu_quality(self, weekday_index: int, recipe: pd.Series):
         quality_check_config = self.config.quality_check
 
         self._ensure_rating_exceed_min(
@@ -290,8 +290,8 @@ class MenuBasic(BaseWithExceptionHandling):
         )
 
         day_type = "workday"
-        if weekday >= 5:
-            day_type = "weekend"
+        if isinstance(weekday_index, int):
+            day_type = Weekday.get_by_index(index=weekday_index).day_type
 
         if not quality_check_config[day_type].recipe_unrated_allowed:
             self._ensure_not_unrated_recipe(recipe=recipe, day_type=day_type)

--- a/sous-chef/sous_chef/menu/create_menu/_menu_basic.py
+++ b/sous-chef/sous_chef/menu/create_menu/_menu_basic.py
@@ -398,14 +398,12 @@ class MenuBasic(BaseWithExceptionHandling):
     ) -> DataFrameBase[TmpMenuSchema]:
         max_cook_active_minutes = None
         if row.override_check == "N":
-            if row.prep_datetime.weekday() < 5:
-                max_cook_active_minutes = float(
-                    self.config.quality_check.workday.cook_active_minutes_max
-                )
-            elif row.prep_datetime.weekday() >= 5:
-                max_cook_active_minutes = float(
-                    self.config.quality_check.weekend.cook_active_minutes_max
-                )
+            weekday = Weekday.get_by_index(row.prep_datetime.weekday())
+            max_cook_active_minutes = float(
+                self.config.quality_check[
+                    weekday.day_type
+                ].cook_active_minutes_max
+            )
 
         exclude_uuid_list = self.menu_history_uuid_list
         if processed_uuid_list:

--- a/sous-chef/tests/unit_tests/abstract/test_extended_enum.py
+++ b/sous-chef/tests/unit_tests/abstract/test_extended_enum.py
@@ -71,3 +71,7 @@ def test_extended_enum_values(string_method, expected_result):
 )
 def test_extended_int_enum(string_method, expected_result):
     assert WhiteRabbitCounts.name_list(string_method) == expected_result
+
+
+def test_extended_enum_cap():
+    assert WhiteRabbitSays("LATE") == WhiteRabbitSays.late

--- a/sous-chef/tests/unit_tests/abstract/test_extended_enum.py
+++ b/sous-chef/tests/unit_tests/abstract/test_extended_enum.py
@@ -17,61 +17,65 @@ class WhiteRabbitSays(ExtendedEnum):
     date = "date"
 
 
+WHITE_RABBIT_SAYS_LIST = [
+    pytest.param("lower", ["late", "important", "date"], id="lowered"),
+    pytest.param("capitalize", ["Late", "Important", "Date"], id="capitalized"),
+    pytest.param("casefold", ["late", "important", "date"], id="casefolded"),
+    pytest.param("upper", ["LATE", "IMPORTANT", "DATE"], id="uppered"),
+]
+
+
+class TestExtendEnum:
+    @staticmethod
+    def test_extension_works_as_expected():
+        @extend_enum([TweedleTwins, WhiteRabbitSays])
+        class SideCharacters(ExtendedEnum):
+            pass
+
+        assert (
+            SideCharacters._member_names_
+            == TweedleTwins._member_names_ + WhiteRabbitSays._member_names_
+        )
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        "string_method,expected_result", WHITE_RABBIT_SAYS_LIST
+    )
+    def test_name_list_as_expected(string_method, expected_result):
+        assert WhiteRabbitSays.name_list(string_method) == expected_result
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        "string_method,expected_result", WHITE_RABBIT_SAYS_LIST
+    )
+    def test_value_as_expected(string_method, expected_result):
+        assert WhiteRabbitSays.value_list(string_method) == expected_result
+
+    @staticmethod
+    def test__missing_works_as_expected():
+        value = "LaTE"
+        # ensure initial test condition is met
+        assert value not in WhiteRabbitSays.name_list("upper")
+
+        assert WhiteRabbitSays(value) == WhiteRabbitSays.late
+
+
 class WhiteRabbitCounts(ExtendedIntEnum):
     months = 12
     weeks = 52
     days = 365
 
 
-def test_extend_enum():
-    @extend_enum([TweedleTwins, WhiteRabbitSays])
-    class SideCharacters(ExtendedEnum):
-        pass
-
-    assert (
-        SideCharacters._member_names_
-        == TweedleTwins._member_names_ + WhiteRabbitSays._member_names_
+class TestExtendIntEnum:
+    @staticmethod
+    @pytest.mark.parametrize(
+        "string_method,expected_result",
+        [
+            ("lower", ["months", "weeks", "days"]),
+            ("capitalize", ["Months", "Weeks", "Days"]),
+            ("casefold", ["months", "weeks", "days"]),
+            ("upper", ["MONTHS", "WEEKS", "DAYS"]),
+        ],
     )
-
-
-@pytest.mark.parametrize(
-    "string_method,expected_result",
-    [
-        ("lower", ["late", "important", "date"]),
-        ("capitalize", ["Late", "Important", "Date"]),
-        ("casefold", ["late", "important", "date"]),
-        ("upper", ["LATE", "IMPORTANT", "DATE"]),
-    ],
-)
-def test_extended_enum(string_method, expected_result):
-    assert WhiteRabbitSays.name_list(string_method) == expected_result
-
-
-@pytest.mark.parametrize(
-    "string_method,expected_result",
-    [
-        ("lower", ["late", "important", "date"]),
-        ("capitalize", ["Late", "Important", "Date"]),
-        ("casefold", ["late", "important", "date"]),
-        ("upper", ["LATE", "IMPORTANT", "DATE"]),
-    ],
-)
-def test_extended_enum_values(string_method, expected_result):
-    assert WhiteRabbitSays.value_list(string_method) == expected_result
-
-
-@pytest.mark.parametrize(
-    "string_method,expected_result",
-    [
-        ("lower", ["months", "weeks", "days"]),
-        ("capitalize", ["Months", "Weeks", "Days"]),
-        ("casefold", ["months", "weeks", "days"]),
-        ("upper", ["MONTHS", "WEEKS", "DAYS"]),
-    ],
-)
-def test_extended_int_enum(string_method, expected_result):
-    assert WhiteRabbitCounts.name_list(string_method) == expected_result
-
-
-def test_extended_enum_cap():
-    assert WhiteRabbitSays("LATE") == WhiteRabbitSays.late
+    def test_extended_int_enum(string_method, expected_result):
+        assert WhiteRabbitCounts.name_list(string_method) == expected_result

--- a/sous-chef/tests/unit_tests/date/test_get_due_date.py
+++ b/sous-chef/tests/unit_tests/date/test_get_due_date.py
@@ -8,6 +8,7 @@ from sous_chef.date.get_due_date import (
     DEFAULT_TIMEZONE,
     DueDatetimeFormatter,
     MealTime,
+    Weekday,
     get_weekday_index,
 )
 from tests.conftest import FROZEN_DATE
@@ -61,20 +62,9 @@ class TestExtendedEnum:
 
 class TestWeekdayIndex:
     @staticmethod
-    @pytest.mark.parametrize(
-        "weekday,index",
-        [
-            ("monday", 0),
-            ("tuesday", 1),
-            ("wednesday", 2),
-            ("thursday", 3),
-            ("friday", 4),
-            ("saturday", 5),
-            ("sunday", 6),
-        ],
-    )
-    def test_check_index(frozen_due_datetime_formatter, weekday, index):
-        assert get_weekday_index(weekday) == index
+    @pytest.mark.parametrize("weekday", Weekday)
+    def test_check_index(frozen_due_datetime_formatter, weekday):
+        assert get_weekday_index(weekday.name) == weekday.index
 
     @staticmethod
     @pytest.mark.parametrize("weekday", ["Monday", "moNDay", "MONDAY"])
@@ -86,31 +76,31 @@ class TestDueDatetimeFormatter:
     @staticmethod
     @freeze_time(FROZEN_MONDAY)
     @pytest.mark.parametrize(
-        "anchor_day,week_offset,expected_day,expected_index",
+        "weekday,week_offset,expected_day",
         [
-            ("Monday", 0, 10, 0),
-            ("Tuesday", 0, 11, 1),
-            ("Wednesday", 0, 12, 2),
-            ("Thursday", 0, 13, 3),
-            ("Friday", 0, 14, 4),
-            ("Saturday", 0, 15, 5),
-            ("Sunday", 0, 16, 6),
-            ("Monday", 1, 17, 0),
-            ("Tuesday", 1, 18, 1),
-            ("Wednesday", 1, 19, 2),
-            ("Thursday", 1, 20, 3),
-            ("Friday", 1, 21, 4),
-            ("Saturday", 1, 22, 5),
-            ("Sunday", 1, 23, 6),
+            (Weekday.monday, 0, 10),
+            (Weekday.tuesday, 0, 11),
+            (Weekday.wednesday, 0, 12),
+            (Weekday.thursday, 0, 13),
+            (Weekday.friday, 0, 14),
+            (Weekday.saturday, 0, 15),
+            (Weekday.sunday, 0, 16),
+            (Weekday.monday, 1, 17),
+            (Weekday.tuesday, 1, 18),
+            (Weekday.wednesday, 1, 19),
+            (Weekday.thursday, 1, 20),
+            (Weekday.friday, 1, 21),
+            (Weekday.saturday, 1, 22),
+            (Weekday.sunday, 1, 23),
         ],
     )
     def test_get_anchor_date(
         config_get_due_date,
-        anchor_day,
+        weekday,
         week_offset,
         expected_day,
-        expected_index,
     ):
+        anchor_day = weekday.name
         config_get_due_date.anchor_day = anchor_day
         config_get_due_date.week_offset = week_offset
         anchor_date = DueDatetimeFormatter(
@@ -119,7 +109,7 @@ class TestDueDatetimeFormatter:
         assert anchor_date == datetime.date(
             year=2022, month=1, day=expected_day
         )
-        assert anchor_date.weekday() == expected_index
+        assert anchor_date.weekday() == weekday.index
 
     @staticmethod
     def test_get_calendar_week(frozen_due_datetime_formatter):
@@ -130,7 +120,7 @@ class TestDueDatetimeFormatter:
         frozen_due_datetime_formatter,
     ):
         assert frozen_due_datetime_formatter.get_due_datetime_with_meal_time(
-            "monday", "dinner"
+            Weekday.monday.name, "dinner"
         ) == create_datetime(day=24, hour=16, minute=30)
 
     @staticmethod
@@ -138,7 +128,7 @@ class TestDueDatetimeFormatter:
         frozen_due_datetime_formatter,
     ):
         assert frozen_due_datetime_formatter.get_due_datetime_with_time(
-            "monday", time=MealTime.dinner.value
+            Weekday.monday.name, time=MealTime.dinner.value
         ) == create_datetime(
             day=24, hour=16, minute=30, tzinfo=DEFAULT_TIMEZONE
         )
@@ -148,29 +138,29 @@ class TestDueDatetimeFormatter:
     @pytest.mark.parametrize(
         "weekday,week_offset,expected_day",
         [
-            ("tuesday", -1, 11),
-            ("wednesday", -1, 12),
-            ("thursday", -1, 13),
-            ("friday", 0, 14),
-            ("saturday", 0, 15),
-            ("sunday", 0, 16),
-            ("monday", 0, 17),
-            ("tuesday", 0, 18),
-            ("wednesday", 0, 19),
-            ("thursday", 0, 20),
-            ("friday", 1, 21),
-            ("saturday", 1, 22),
-            ("sunday", 1, 23),
-            ("monday", 1, 17),
-            ("tuesday", 1, 18),
-            ("wednesday", 1, 19),
-            ("thursday", 1, 20),
+            (Weekday.tuesday, -1, 11),
+            (Weekday.wednesday, -1, 12),
+            (Weekday.thursday, -1, 13),
+            (Weekday.friday, 0, 14),
+            (Weekday.saturday, 0, 15),
+            (Weekday.sunday, 0, 16),
+            (Weekday.monday, 0, 17),
+            (Weekday.tuesday, 0, 18),
+            (Weekday.wednesday, 0, 19),
+            (Weekday.thursday, 0, 20),
+            (Weekday.friday, 1, 21),
+            (Weekday.saturday, 1, 22),
+            (Weekday.sunday, 1, 23),
+            (Weekday.monday, 1, 17),
+            (Weekday.tuesday, 1, 18),
+            (Weekday.wednesday, 1, 19),
+            (Weekday.thursday, 1, 20),
         ],
     )
     def test__get_anchor_date_at_midnight(
         frozen_due_datetime_formatter, weekday, week_offset, expected_day
     ):
-        frozen_due_datetime_formatter.anchor_day = weekday
+        frozen_due_datetime_formatter.anchor_day = weekday.name
         frozen_due_datetime_formatter.week_offset = week_offset
         assert (
             frozen_due_datetime_formatter._get_anchor_date_at_midnight()
@@ -182,42 +172,42 @@ class TestDueDatetimeFormatter:
     @pytest.mark.parametrize(
         "weekday,day",
         [
-            ("wednesday", 19),
-            ("thursday", 20),
-            ("friday", 21),
-            ("saturday", 22),
-            ("sunday", 23),
-            ("monday", 24),
-            ("tuesday", 18),
+            (Weekday.wednesday, 19),
+            (Weekday.thursday, 20),
+            (Weekday.friday, 21),
+            (Weekday.saturday, 22),
+            (Weekday.sunday, 23),
+            (Weekday.monday, 24),
+            (Weekday.tuesday, 18),
         ],
     )
     def test_get_date_relative_to_anchor_tuesday(
         config_get_due_date, weekday, day
     ):
-        config_get_due_date.anchor_day = "Tuesday"
+        config_get_due_date.anchor_day = Weekday.tuesday.name
         config_get_due_date.week_offset = 1
         assert DueDatetimeFormatter(
             config=config_get_due_date
-        ).get_date_relative_to_anchor(weekday) == create_datetime(day=day)
+        ).get_date_relative_to_anchor(weekday.name) == create_datetime(day=day)
 
     @staticmethod
     @pytest.mark.parametrize(
         "weekday,day",
         [
-            ("saturday", 22),
-            ("sunday", 23),
-            ("monday", 24),
-            ("tuesday", 25),
-            ("wednesday", 26),
-            ("thursday", 27),
-            ("friday", 21),
+            (Weekday.saturday, 22),
+            (Weekday.sunday, 23),
+            (Weekday.monday, 24),
+            (Weekday.tuesday, 25),
+            (Weekday.wednesday, 26),
+            (Weekday.thursday, 27),
+            (Weekday.friday, 21),
         ],
     )
     def test_get_date_relative_to_anchor_friday(
         frozen_due_datetime_formatter, weekday, day
     ):
         assert frozen_due_datetime_formatter.get_date_relative_to_anchor(
-            weekday
+            weekday.name
         ) == create_datetime(day=day)
 
     @staticmethod

--- a/sous-chef/tests/unit_tests/date/test_get_due_date.py
+++ b/sous-chef/tests/unit_tests/date/test_get_due_date.py
@@ -221,24 +221,6 @@ class TestDueDatetimeFormatter:
         ) == create_datetime(day=day)
 
     @staticmethod
-    @pytest.mark.parametrize("meal_time", MealTime)
-    def test__get_meal_time(frozen_due_datetime_formatter, meal_time):
-        assert (
-            frozen_due_datetime_formatter._get_meal_time(meal_time.name)
-            == meal_time.value
-        )
-
-    @staticmethod
-    @pytest.mark.parametrize("meal_time", ["Dinner", "diNNeR", "DINNER"])
-    def test__get_meal_time_alternate_capitalization(
-        frozen_due_datetime_formatter, meal_time
-    ):
-        assert (
-            frozen_due_datetime_formatter._get_meal_time(meal_time)
-            == MealTime.dinner.value
-        )
-
-    @staticmethod
     @pytest.mark.parametrize("hour,minute", [(0, 0), (1, 31), (23, 59)])
     def test__set_specified_time(frozen_due_datetime_formatter, hour, minute):
         initial_datetime = create_datetime(day=17)

--- a/sous-chef/tests/unit_tests/menu/create_menu/test_create_menu.py
+++ b/sous-chef/tests/unit_tests/menu/create_menu/test_create_menu.py
@@ -295,6 +295,4 @@ class TestGetWeekdayFromShort:
         # derived exception MenuConfigError
         with pytest.raises(Exception) as error:
             get_weekday_from_short("not-a-day")
-        assert (
-            str(error.value) == "[menu config error] not-a-day unknown weekday!"
-        )
+        assert str(error.value) == "[menu config error] not-a-day unknown day!"

--- a/sous-chef/tests/unit_tests/menu/create_menu/test_create_menu.py
+++ b/sous-chef/tests/unit_tests/menu/create_menu/test_create_menu.py
@@ -2,6 +2,7 @@ import numpy as np
 import pandas as pd
 import pytest
 from freezegun import freeze_time
+from sous_chef.date.get_due_date import Weekday
 from sous_chef.formatter.ingredient.format_ingredient import Ingredient
 from sous_chef.formatter.units import unit_registry
 from sous_chef.menu.create_menu._for_grocery_list import (
@@ -11,6 +12,10 @@ from sous_chef.menu.create_menu._for_grocery_list import (
 from sous_chef.menu.create_menu._menu_basic import get_weekday_from_short
 from tests.conftest import FROZEN_DATE
 from tests.unit_tests.util import create_recipe
+
+WEEKDAY_INT = [
+    pytest.param(member.value.index, id=member.name) for member in Weekday
+]
 
 
 @pytest.fixture
@@ -57,7 +62,7 @@ class TestMenu:
         assert result["time_total"] is pd.NaT
 
     @staticmethod
-    @pytest.mark.parametrize("weekday", [0, 1, 2, 3, 4, 5, 6])
+    @pytest.mark.parametrize("weekday", WEEKDAY_INT)
     def test__check_menu_quality(menu, menu_config, weekday):
         menu_config.quality_check.recipe_rating_min = 3.0
         menu_config.quality_check.workday.recipe_unrated_allowed = True
@@ -71,7 +76,7 @@ class TestMenu:
         )
 
     @staticmethod
-    @pytest.mark.parametrize("weekday", [0, 1, 2, 3, 4, 5, 6])
+    @pytest.mark.parametrize("weekday", WEEKDAY_INT)
     def test__check_menu_quality_ensure_rating_exceed_min(
         menu, menu_config, weekday
     ):
@@ -87,7 +92,7 @@ class TestMenu:
         )
 
     @staticmethod
-    @pytest.mark.parametrize("weekday", [0, 1, 2, 3, 4, 5, 6])
+    @pytest.mark.parametrize("weekday", WEEKDAY_INT)
     def test__check_menu_quality_ensure_workday_not_unrated_recipe(
         menu, menu_config, weekday
     ):
@@ -107,7 +112,7 @@ class TestMenu:
         )
 
     @staticmethod
-    @pytest.mark.parametrize("weekday", [0, 1, 2, 3, 4, 5, 6])
+    @pytest.mark.parametrize("weekday", WEEKDAY_INT)
     def test__check_menu_quality_ensure_workday_not_exceed_active_cook_time(
         menu, menu_config, weekday
     ):


### PR DESCRIPTION
afaik, the ExtendedEnum is used for cases where the values are not exclusively strings (as was initially proposed & not properly countered). The StrEnum has interesting options, but as it's another dependency and doesn't handle our use case without extension & it's not been developed since 2023, I'd argue that we keep what we have.