### PR TITLE
Eggs are now more correctly attributed to Lidl.

### DIFF
--- a/sous-chef/tests/data/final_grocery_list.csv
+++ b/sous-chef/tests/data/final_grocery_list.csv
@@ -8,7 +8,7 @@ tablespoon,cinnamon powder,False,1.0,Spices and herbs,cinnamon powder,Amazon,,[B
 gram,cream cheese,False,875.0,Dairy products,cream cheese,grocery store,7622300315733,[Holiday cheesecake],2022-01-23 09:45:00+00:00,[Sun],2022-01-14,Dairy force
 teaspoon,dried oregano,False,1.0,Spices and herbs,dried oregano,grocery store,,[Spanish Deluxe Potatoes],2022-01-23 16:30:00+00:00,[Sun],2022-01-14,Spices and herbs
 teaspoon,dried parsley,False,1.0,Spices and herbs,dried parsley,grocery store,,[Spanish Deluxe Potatoes],2022-01-23 16:30:00+00:00,[Sun],2022-01-14,Spices and herbs
-dimensionless,egg,False,4.0,Egg,eggs,grocery store,,"[Holiday cheesecake, Lasagna]",2022-01-23 09:45:00+00:00,"[Sun, Tue]",2022-01-14,Bulk
+dimensionless,egg,False,4.0,Egg,eggs,Lidl,,"[Holiday cheesecake, Lasagna]",2022-01-23 09:45:00+00:00,"[Sun, Tue]",2022-01-14,Lidl
 cup,flour,False,0.5,Prepared,flour,Homemade,,[Baked Oatmeal Bars],2022-01-23 16:30:00+00:00,[Sun],2022-01-14,Homemade
 head,frisée,False,1.0,Lettuce,frisée,grocery store,,[manual],2022-01-26 16:10:00+00:00,[Wed],2022-01-24,Farmland pride
 tablespoon,garlic paste,False,1.0,Sauces,garlic paste,Asian store,0608171040131,"[Lasagna, Spanish Deluxe Potatoes]",2022-01-23 16:30:00+00:00,"[Sun, Tue]",2022-01-14,Asian store


### PR DESCRIPTION
* We should consider updating these e2e to not be reliant on a static pantry list, which ours approximately is. It's silly to have to update this csv due to a minor change like this. It would be better to make a static pantry list, as there are many small changes that when propagated would require manual work to fix.