### PR TITLE
Decouple menu for grocery list

### DIFF
--- a/.idea/runConfigurations/_sous_chef__menu_dev.xml
+++ b/.idea/runConfigurations/_sous_chef__menu_dev.xml
@@ -29,7 +29,7 @@
       <option name="useCurrentConnection" value="false" />
     </EXTENSION>
     <option name="SCRIPT_NAME" value="$PROJECT_DIR$/sous-chef/sous_chef/menu/main.py" />
-    <option name="PARAMETERS" value="menu.create_menu.fixed.menu_number=6 menu.run_mode.with_todoist=false" />
+    <option name="PARAMETERS" value="menu.create_menu.fixed.menu_number=6 menu.create_menu.todoist.is_active=false" />
     <option name="SHOW_COMMAND_LINE" value="false" />
     <option name="EMULATE_TERMINAL" value="true" />
     <option name="MODULE_MODE" value="false" />

--- a/.idea/runConfigurations/_sous_chef__menu_prod.xml
+++ b/.idea/runConfigurations/_sous_chef__menu_prod.xml
@@ -29,7 +29,7 @@
       <option name="useCurrentConnection" value="false" />
     </EXTENSION>
     <option name="SCRIPT_NAME" value="$PROJECT_DIR$/sous-chef/sous_chef/menu/main.py" />
-    <option name="PARAMETERS" value="menu.create_menu.input_method=&quot;final&quot;" />
+    <option name="PARAMETERS" value="menu.create_menu.input_method=&quot;final&quot; menu.create_menu.todoist.is_active=true" />
     <option name="SHOW_COMMAND_LINE" value="false" />
     <option name="EMULATE_TERMINAL" value="true" />
     <option name="MODULE_MODE" value="false" />

--- a/sous-chef/config/menu/create_menu.yaml
+++ b/sous-chef/config/menu/create_menu.yaml
@@ -25,6 +25,7 @@ create_menu:
     menu_quality_check: raise
     menu_future_error: raise
   todoist:
+    is_active: false
     project_name: Menu
     remove_existing_task: false
     task_priority: 3

--- a/sous-chef/config/menu_main.yaml
+++ b/sous-chef/config/menu_main.yaml
@@ -25,5 +25,3 @@ menu:
       menu_future_error: log
     todoist:
       remove_existing_task: true
-  run_mode:
-    with_todoist: true

--- a/sous-chef/sous_chef/menu/create_menu/_for_grocery_list.py
+++ b/sous-chef/sous_chef/menu/create_menu/_for_grocery_list.py
@@ -12,10 +12,8 @@ from sous_chef.formatter.ingredient.format_ingredient import (
     IngredientFormatter,
     MapIngredientErrorToException,
 )
-from sous_chef.menu.create_menu._menu_basic import (
-    MenuIncompleteError,
-    TmpMenuSchema,
-)
+from sous_chef.menu.create_menu._menu_basic import MenuIncompleteError
+from sous_chef.menu.create_menu.models import TmpMenuSchema
 from sous_chef.recipe_book.read_recipe_book import RecipeBook
 from sous_chef.recipe_book.recipe_util import (
     MapRecipeErrorToException,

--- a/sous-chef/sous_chef/menu/create_menu/_for_grocery_list.py
+++ b/sous-chef/sous_chef/menu/create_menu/_for_grocery_list.py
@@ -10,15 +10,20 @@ from sous_chef.abstract.handle_exception import BaseWithExceptionHandling
 from sous_chef.formatter.ingredient.format_ingredient import (
     Ingredient,
     IngredientFormatter,
+    MapIngredientErrorToException,
 )
 from sous_chef.menu.create_menu._menu_basic import (
     LoadedMenuSchema,
-    MapMenuErrorToException,
     MenuIncompleteError,
 )
 from sous_chef.recipe_book.read_recipe_book import RecipeBook
-from sous_chef.recipe_book.recipe_util import RecipeSchema
+from sous_chef.recipe_book.recipe_util import (
+    MapRecipeErrorToException,
+    RecipeSchema,
+)
 from termcolor import cprint
+
+from utilities.extended_enum import ExtendedEnum, extend_enum
 
 
 @dataclass
@@ -37,6 +42,16 @@ class MenuRecipe:
     from_recipe: str
 
 
+@extend_enum(
+    [
+        MapIngredientErrorToException,
+        MapRecipeErrorToException,
+    ]
+)
+class MapMenuForGroceryListErrorToException(ExtendedEnum):
+    pass
+
+
 class MenuForGroceryList(BaseWithExceptionHandling):
     def __init__(
         self,
@@ -51,7 +66,7 @@ class MenuForGroceryList(BaseWithExceptionHandling):
 
         self.set_tuple_log_and_skip_exception_from_config(
             config_errors=config_errors,
-            exception_mapper=MapMenuErrorToException,
+            exception_mapper=MapMenuForGroceryListErrorToException,
         )
 
     def get_menu_for_grocery_list(

--- a/sous-chef/sous_chef/menu/create_menu/_for_grocery_list.py
+++ b/sous-chef/sous_chef/menu/create_menu/_for_grocery_list.py
@@ -13,8 +13,8 @@ from sous_chef.formatter.ingredient.format_ingredient import (
     MapIngredientErrorToException,
 )
 from sous_chef.menu.create_menu._menu_basic import (
-    LoadedMenuSchema,
     MenuIncompleteError,
+    TmpMenuSchema,
 )
 from sous_chef.recipe_book.read_recipe_book import RecipeBook
 from sous_chef.recipe_book.recipe_util import (
@@ -56,7 +56,7 @@ class MenuForGroceryList(BaseWithExceptionHandling):
     def __init__(
         self,
         config_errors: DictConfig,
-        final_menu_df: DataFrameBase[LoadedMenuSchema],
+        final_menu_df: DataFrameBase[TmpMenuSchema],
         ingredient_formatter: IngredientFormatter,
         recipe_book: RecipeBook,
     ):

--- a/sous-chef/sous_chef/menu/create_menu/_for_grocery_list.py
+++ b/sous-chef/sous_chef/menu/create_menu/_for_grocery_list.py
@@ -4,12 +4,19 @@ from dataclasses import dataclass
 from typing import List
 
 import pandas as pd
+from omegaconf import DictConfig
+from pandera.typing.common import DataFrameBase
 from sous_chef.abstract.handle_exception import BaseWithExceptionHandling
-from sous_chef.formatter.ingredient.format_ingredient import Ingredient
+from sous_chef.formatter.ingredient.format_ingredient import (
+    Ingredient,
+    IngredientFormatter,
+)
 from sous_chef.menu.create_menu._menu_basic import (
-    MenuBasic,
+    LoadedMenuSchema,
+    MapMenuErrorToException,
     MenuIncompleteError,
 )
+from sous_chef.recipe_book.read_recipe_book import RecipeBook
 from sous_chef.recipe_book.recipe_util import RecipeSchema
 from termcolor import cprint
 
@@ -30,13 +37,27 @@ class MenuRecipe:
     from_recipe: str
 
 
-class MenuForGroceryList(MenuBasic):
+class MenuForGroceryList(BaseWithExceptionHandling):
+    def __init__(
+        self,
+        config_errors: DictConfig,
+        final_menu_df: DataFrameBase[LoadedMenuSchema],
+        ingredient_formatter: IngredientFormatter,
+        recipe_book: RecipeBook,
+    ):
+        self.dataframe = final_menu_df
+        self.ingredient_formatter = ingredient_formatter
+        self.recipe_book = recipe_book
+
+        self.set_tuple_log_and_skip_exception_from_config(
+            config_errors=config_errors,
+            exception_mapper=MapMenuErrorToException,
+        )
+
     def get_menu_for_grocery_list(
         self,
     ) -> (List[MenuIngredient], List[MenuRecipe]):
         self.record_exception = []
-
-        self.load_final_menu()
 
         entry_funcs = {
             "ingredient": self._retrieve_manual_menu_ingredient,
@@ -62,8 +83,13 @@ class MenuForGroceryList(MenuBasic):
     def _retrieve_manual_menu_ingredient(
         self, row: pd.Series
     ) -> MenuIngredient:
+        ingredient = self.ingredient_formatter.format_manual_ingredient(
+            quantity=float(row["eat_factor"]),
+            unit=row["eat_unit"],
+            item=row["item"],
+        )
         return MenuIngredient(
-            ingredient=self._check_manual_ingredient(row),
+            ingredient=ingredient,
             from_recipe="manual",
             for_day=row["prep_datetime"],
         )

--- a/sous-chef/sous_chef/menu/create_menu/_for_todoist.py
+++ b/sous-chef/sous_chef/menu/create_menu/_for_todoist.py
@@ -5,7 +5,7 @@ import pandas as pd
 from omegaconf import DictConfig
 from pandera.typing.common import DataFrameBase
 from sous_chef.date.get_due_date import DueDatetimeFormatter
-from sous_chef.menu.create_menu._menu_basic import LoadedMenuSchema
+from sous_chef.menu.create_menu._menu_basic import TmpMenuSchema
 
 from utilities.api.todoist_api import TodoistHelper
 
@@ -14,7 +14,7 @@ class MenuForTodoist:
     def __init__(
         self,
         config: DictConfig,
-        final_menu_df: DataFrameBase[LoadedMenuSchema],
+        final_menu_df: DataFrameBase[TmpMenuSchema],
         due_date_formatter: DueDatetimeFormatter,
         todoist_helper: TodoistHelper,
     ):

--- a/sous-chef/sous_chef/menu/create_menu/_for_todoist.py
+++ b/sous-chef/sous_chef/menu/create_menu/_for_todoist.py
@@ -5,7 +5,7 @@ import pandas as pd
 from omegaconf import DictConfig
 from pandera.typing.common import DataFrameBase
 from sous_chef.date.get_due_date import DueDatetimeFormatter
-from sous_chef.menu.create_menu._menu_basic import TmpMenuSchema
+from sous_chef.menu.create_menu.models import TmpMenuSchema
 
 from utilities.api.todoist_api import TodoistHelper
 

--- a/sous-chef/sous_chef/menu/create_menu/_for_todoist.py
+++ b/sous-chef/sous_chef/menu/create_menu/_for_todoist.py
@@ -14,13 +14,13 @@ class MenuForTodoist:
     def __init__(
         self,
         config: DictConfig,
-        dataframe: DataFrameBase[LoadedMenuSchema],
+        final_menu_df: DataFrameBase[LoadedMenuSchema],
         due_date_formatter: DueDatetimeFormatter,
         todoist_helper: TodoistHelper,
     ):
         # data classes
         self.due_date_formatter = due_date_formatter
-        self.dataframe = dataframe
+        self.dataframe = final_menu_df
         self.todoist_helper = todoist_helper
         # settings
         self.project_name = config.project_name

--- a/sous-chef/sous_chef/menu/create_menu/_from_fixed_template.py
+++ b/sous-chef/sous_chef/menu/create_menu/_from_fixed_template.py
@@ -9,15 +9,17 @@ from pandera.typing.common import DataFrameBase
 from sous_chef.abstract.handle_exception import BaseWithExceptionHandling
 from sous_chef.date.get_due_date import DueDatetimeFormatter
 from sous_chef.menu.create_menu._menu_basic import (
+    MenuBasic,
+    MenuIncompleteError,
+    get_weekday_from_short,
+    validate_menu_schema,
+)
+from sous_chef.menu.create_menu.models import (
     AllMenuSchema,
     BasicMenuSchema,
     LoadedMenuSchema,
-    MenuBasic,
-    MenuIncompleteError,
     Season,
     TmpMenuSchema,
-    get_weekday_from_short,
-    validate_menu_schema,
 )
 from structlog import get_logger
 from termcolor import cprint

--- a/sous-chef/sous_chef/menu/create_menu/_from_fixed_template.py
+++ b/sous-chef/sous_chef/menu/create_menu/_from_fixed_template.py
@@ -6,6 +6,7 @@ import numpy as np
 import pandas as pd
 from omegaconf import DictConfig
 from pandera.typing.common import DataFrameBase
+from sous_chef.abstract.handle_exception import BaseWithExceptionHandling
 from sous_chef.date.get_due_date import DueDatetimeFormatter
 from sous_chef.menu.create_menu._menu_basic import (
     AllMenuSchema,
@@ -125,11 +126,16 @@ class MenuFromFixedTemplate(MenuBasic):
             future_uuid_tuple=future_uuid_tuple,
         )
 
+    @BaseWithExceptionHandling.ExceptionHandler.handle_exception
     def _process_ingredient(
         self, row: pd.Series
     ) -> DataFrameBase[TmpMenuSchema]:
         # do NOT need returned, as just ensuring exists
-        self._check_manual_ingredient(row=row)
+        self.ingredient_formatter.format_manual_ingredient(
+            quantity=float(row["eat_factor"]),
+            unit=row["eat_unit"],
+            item=row["item"],
+        )
 
         row["time_total"] = timedelta(
             minutes=int(self.config.ingredient.default_cook_minutes)

--- a/sous-chef/sous_chef/menu/create_menu/_menu_basic.py
+++ b/sous-chef/sous_chef/menu/create_menu/_menu_basic.py
@@ -226,9 +226,6 @@ class MenuBasic(BaseWithExceptionHandling):
             dataframe=self.dataframe, model=TmpMenuSchema
         )
 
-    def save_with_menu_historian(self):
-        self.menu_historian.add_current_menu_to_history(self.dataframe)
-
     def _add_recipe_columns(
         self, row: pd.Series, recipe: pd.Series
     ) -> pd.Series:

--- a/sous-chef/sous_chef/menu/create_menu/_menu_basic.py
+++ b/sous-chef/sous_chef/menu/create_menu/_menu_basic.py
@@ -5,12 +5,10 @@ from pathlib import Path
 from typing import List, Optional, Tuple, Union
 
 import pandas as pd
-import pandera as pa
 from omegaconf import DictConfig
-from pandera.typing import Series
 from pandera.typing.common import DataFrameBase
 from sous_chef.abstract.handle_exception import BaseWithExceptionHandling
-from sous_chef.date.get_due_date import DueDatetimeFormatter, MealTime, Weekday
+from sous_chef.date.get_due_date import DueDatetimeFormatter, Weekday
 from sous_chef.formatter.ingredient.format_ingredient import (
     IngredientFormatter,
     MapIngredientErrorToException,
@@ -18,6 +16,7 @@ from sous_chef.formatter.ingredient.format_ingredient import (
 from sous_chef.formatter.ingredient.format_line_abstract import (
     MapLineErrorToException,
 )
+from sous_chef.menu.create_menu.models import LoadedMenuSchema, TmpMenuSchema
 from sous_chef.menu.record_menu_history import (
     MapMenuHistoryErrorToException,
     MenuHistorian,
@@ -28,32 +27,10 @@ from sous_chef.recipe_book.recipe_util import MapRecipeErrorToException
 from structlog import get_logger
 
 from utilities.api.gsheets_api import GsheetsHelper
-from utilities.extended_enum import ExtendedEnum, ExtendedIntEnum, extend_enum
+from utilities.extended_enum import ExtendedEnum, extend_enum
 
 ABS_FILE_PATH = Path(__file__).absolute().parent
 FILE_LOGGER = get_logger(__name__)
-
-
-class TypeProcessOrder(ExtendedIntEnum):
-    recipe = 0
-    ingredient = 1
-    filter = 2
-    tag = 3
-    category = 4
-
-
-class RandomSelectType(ExtendedEnum):
-    rated = "rated"
-    unrated = "unrated"
-    either = "either"
-
-
-class Season(ExtendedEnum):
-    any = "0_any"
-    winter = "1_winter"
-    spring = "2_spring"
-    summer = "3_summer"
-    fall = "4_fall"
 
 
 # TODO method to scale recipe to desired servings? maybe in recipe checker?
@@ -122,72 +99,6 @@ class MenuFutureError(Exception):
 class MapMenuErrorToException(ExtendedEnum):
     menu_quality_check = MenuQualityError
     menu_future_error = MenuFutureError
-
-
-class BasicMenuSchema(pa.SchemaModel):
-    # TODO replace all panderas with pydantic & create own validator with
-    #  dataframe returned, as no default functions & coerce is poorly made
-    weekday: Series[str] = pa.Field(isin=Weekday.name_list("capitalize"))
-    meal_time: Series[str] = pa.Field(isin=MealTime.name_list("lower"))
-    type: Series[str] = pa.Field(isin=TypeProcessOrder.name_list())
-    eat_factor: Series[float] = pa.Field(
-        ge=0, default=0, nullable=False, coerce=True
-    )
-    eat_unit: Series[str] = pa.Field(nullable=True)
-    freeze_factor: Series[float] = pa.Field(
-        ge=0, default=0, nullable=False, coerce=True
-    )
-    defrost: Series[str] = pa.Field(
-        isin=["Y", "N"], default="N", nullable=False, coerce=True
-    )
-    item: Series[str]
-
-    class Config:
-        strict = True
-        coerce = True
-
-
-class InProgressSchema(BasicMenuSchema):
-    selection: Series[str] = pa.Field(
-        isin=RandomSelectType.name_list(), nullable=True
-    )
-    prep_day: Optional[Series[float]] = pa.Field(
-        ge=0, lt=7, default=0, nullable=False, coerce=True
-    )
-    override_check: Series[str] = pa.Field(
-        isin=["Y", "N"], default="N", nullable=False, coerce=True
-    )
-
-
-class AllMenuSchema(InProgressSchema):
-    menu: Series[int] = pa.Field(ge=0, nullable=False)
-    season: Series[str] = pa.Field(isin=Season.value_list(), nullable=False)
-
-
-class TimeSchema(pa.SchemaModel):
-    cook_datetime: Optional[Series[pd.DatetimeTZDtype]] = pa.Field(
-        dtype_kwargs={"unit": "ns", "tz": "UTC"}, coerce=True
-    )
-    prep_datetime: Series[pd.DatetimeTZDtype] = pa.Field(
-        dtype_kwargs={"unit": "ns", "tz": "UTC"}, coerce=True, nullable=False
-    )
-
-
-class LoadedMenuSchema(InProgressSchema, TimeSchema):
-    pass
-
-
-class TmpMenuSchema(BasicMenuSchema, TimeSchema):
-    # override as should be replaced with one of these
-    type: Series[str] = pa.Field(isin=["ingredient", "recipe"])
-    time_total: Series[pd.Timedelta] = pa.Field(nullable=False, coerce=True)
-    # manual ingredients lack these
-    rating: Series[float] = pa.Field(nullable=True, coerce=True)
-    uuid: Series[str] = pa.Field(nullable=True)
-
-    class Config:
-        strict = True
-        coerce = True
 
 
 @dataclass

--- a/sous-chef/sous_chef/menu/create_menu/_menu_basic.py
+++ b/sous-chef/sous_chef/menu/create_menu/_menu_basic.py
@@ -214,18 +214,6 @@ class MenuBasic(BaseWithExceptionHandling):
         )
         self.menu_history_uuid_list = self._set_menu_history_uuid_list()
 
-    def load_final_menu(self):
-        worksheet = self.config.final_menu.worksheet
-
-        workbook = self.gsheets_helper.get_workbook(
-            self.config.final_menu.workbook
-        )
-        self.dataframe = workbook.get_worksheet(worksheet_name=worksheet)
-        self.dataframe.time_total = pd.to_timedelta(self.dataframe.time_total)
-        self.dataframe = validate_menu_schema(
-            dataframe=self.dataframe, model=TmpMenuSchema
-        )
-
     def _add_recipe_columns(
         self, row: pd.Series, recipe: pd.Series
     ) -> pd.Series:

--- a/sous-chef/sous_chef/menu/create_menu/_menu_basic.py
+++ b/sous-chef/sous_chef/menu/create_menu/_menu_basic.py
@@ -269,14 +269,6 @@ class MenuBasic(BaseWithExceptionHandling):
         self._inspect_unrated_recipe(recipe)
         return row
 
-    @BaseWithExceptionHandling.ExceptionHandler.handle_exception
-    def _check_manual_ingredient(self, row: pd.Series):
-        return self.ingredient_formatter.format_manual_ingredient(
-            quantity=float(row["eat_factor"]),
-            unit=row["eat_unit"],
-            item=row["item"],
-        )
-
     def _check_menu_quality(self, weekday_index: int, recipe: pd.Series):
         quality_check_config = self.config.quality_check
 

--- a/sous-chef/sous_chef/menu/create_menu/create_menu.py
+++ b/sous-chef/sous_chef/menu/create_menu/create_menu.py
@@ -13,10 +13,8 @@ from sous_chef.menu.create_menu._for_todoist import MenuForTodoist
 from sous_chef.menu.create_menu._from_fixed_template import (
     MenuFromFixedTemplate,
 )
-from sous_chef.menu.create_menu._menu_basic import (
-    TmpMenuSchema,
-    validate_menu_schema,
-)
+from sous_chef.menu.create_menu._menu_basic import validate_menu_schema
+from sous_chef.menu.create_menu.models import TmpMenuSchema
 from structlog import get_logger
 
 from utilities.api.todoist_api import TodoistHelper
@@ -30,7 +28,9 @@ class Menu(MenuFromFixedTemplate):
     def temporarily_output_menu_for_review(self):
         pass
 
-    def finalize_menu_to_external_services(self):
+    def finalize_menu_to_external_services(
+        self,
+    ) -> DataFrameBase[TmpMenuSchema]:
         final_menu_df = self._load_final_menu()
         self.menu_historian.add_current_menu_to_history(
             current_menu=final_menu_df
@@ -41,6 +41,7 @@ class Menu(MenuFromFixedTemplate):
             self._upload_menu_to_todoist(
                 final_menu_df=final_menu_df, todoist_helper=todoist_helper
             )
+        return final_menu_df
 
     def get_menu_for_grocery_list(
         self,

--- a/sous-chef/sous_chef/menu/create_menu/create_menu.py
+++ b/sous-chef/sous_chef/menu/create_menu/create_menu.py
@@ -1,7 +1,6 @@
 from dataclasses import dataclass
 from pathlib import Path
 
-from sous_chef.menu.create_menu._for_grocery_list import MenuForGroceryList
 from sous_chef.menu.create_menu._for_todoist import MenuForTodoist
 from sous_chef.menu.create_menu._from_fixed_template import (
     MenuFromFixedTemplate,
@@ -15,7 +14,7 @@ FILE_LOGGER = get_logger(__name__)
 
 
 @dataclass
-class Menu(MenuForGroceryList, MenuFromFixedTemplate):
+class Menu(MenuFromFixedTemplate):
     def temporarily_output_menu_for_review(self):
         pass
 
@@ -25,7 +24,7 @@ class Menu(MenuForGroceryList, MenuFromFixedTemplate):
     def upload_menu_to_todoist(self, todoist_helper: TodoistHelper):
         menu_for_todoist = MenuForTodoist(
             config=self.config.todoist,
-            dataframe=self.dataframe,
+            final_menu_df=self.dataframe,
             due_date_formatter=self.due_date_formatter,
             todoist_helper=todoist_helper,
         )

--- a/sous-chef/sous_chef/menu/create_menu/create_menu.py
+++ b/sous-chef/sous_chef/menu/create_menu/create_menu.py
@@ -30,10 +30,10 @@ class Menu(MenuFromFixedTemplate):
     def get_menu_for_grocery_list(
         self,
     ) -> (List[MenuIngredient], List[MenuRecipe]):
-        final_menu_df = self.load_final_menu()
+        self.load_final_menu()
         menu_for_grocery_list = MenuForGroceryList(
             config_errors=self.config.errors,
-            final_menu_df=final_menu_df,
+            final_menu_df=self.dataframe,
             ingredient_formatter=self.ingredient_formatter,
             recipe_book=self.recipe_book,
         )

--- a/sous-chef/sous_chef/menu/create_menu/create_menu.py
+++ b/sous-chef/sous_chef/menu/create_menu/create_menu.py
@@ -1,6 +1,12 @@
 from dataclasses import dataclass
 from pathlib import Path
+from typing import List
 
+from sous_chef.menu.create_menu._for_grocery_list import (
+    MenuForGroceryList,
+    MenuIngredient,
+    MenuRecipe,
+)
 from sous_chef.menu.create_menu._for_todoist import MenuForTodoist
 from sous_chef.menu.create_menu._from_fixed_template import (
     MenuFromFixedTemplate,
@@ -20,6 +26,18 @@ class Menu(MenuFromFixedTemplate):
 
     def finalize_menu_to_external_services(self):
         pass
+
+    def get_menu_for_grocery_list(
+        self,
+    ) -> (List[MenuIngredient], List[MenuRecipe]):
+        final_menu_df = self.load_final_menu()
+        menu_for_grocery_list = MenuForGroceryList(
+            config_errors=self.config.errors,
+            final_menu_df=final_menu_df,
+            ingredient_formatter=self.ingredient_formatter,
+            recipe_book=self.recipe_book,
+        )
+        return menu_for_grocery_list.get_menu_for_grocery_list()
 
     def upload_menu_to_todoist(self, todoist_helper: TodoistHelper):
         menu_for_todoist = MenuForTodoist(

--- a/sous-chef/sous_chef/menu/create_menu/create_menu.py
+++ b/sous-chef/sous_chef/menu/create_menu/create_menu.py
@@ -16,6 +16,12 @@ FILE_LOGGER = get_logger(__name__)
 
 @dataclass
 class Menu(MenuForGroceryList, MenuFromFixedTemplate):
+    def temporarily_output_menu_for_review(self):
+        pass
+
+    def finalize_menu_to_external_services(self):
+        pass
+
     def upload_menu_to_todoist(self, todoist_helper: TodoistHelper):
         menu_for_todoist = MenuForTodoist(
             config=self.config.todoist,

--- a/sous-chef/sous_chef/menu/create_menu/create_menu.py
+++ b/sous-chef/sous_chef/menu/create_menu/create_menu.py
@@ -25,7 +25,12 @@ class Menu(MenuFromFixedTemplate):
         pass
 
     def finalize_menu_to_external_services(self):
-        pass
+        self.load_final_menu()
+        self.save_with_menu_historian()
+
+        if self.config.menu.run_mode.with_todoist:
+            todoist_helper = TodoistHelper(self.config.api.todoist)
+            self._upload_menu_to_todoist(todoist_helper)
 
     def get_menu_for_grocery_list(
         self,
@@ -39,7 +44,7 @@ class Menu(MenuFromFixedTemplate):
         )
         return menu_for_grocery_list.get_menu_for_grocery_list()
 
-    def upload_menu_to_todoist(self, todoist_helper: TodoistHelper):
+    def _upload_menu_to_todoist(self, todoist_helper: TodoistHelper):
         menu_for_todoist = MenuForTodoist(
             config=self.config.todoist,
             final_menu_df=self.dataframe,

--- a/sous-chef/sous_chef/menu/create_menu/create_menu.py
+++ b/sous-chef/sous_chef/menu/create_menu/create_menu.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from typing import List
 
 import pandas as pd
+from omegaconf import DictConfig
 from pandera.typing.common import DataFrameBase
 from sous_chef.menu.create_menu._for_grocery_list import (
     MenuForGroceryList,
@@ -29,15 +30,15 @@ class Menu(MenuFromFixedTemplate):
         pass
 
     def finalize_menu_to_external_services(
-        self,
+        self, config_todoist: DictConfig
     ) -> DataFrameBase[TmpMenuSchema]:
         final_menu_df = self._load_final_menu()
         self.menu_historian.add_current_menu_to_history(
             current_menu=final_menu_df
         )
 
-        if self.config.menu.run_mode.with_todoist:
-            todoist_helper = TodoistHelper(self.config.api.todoist)
+        if self.config.todoist.is_active:
+            todoist_helper = TodoistHelper(config_todoist)
             self._upload_menu_to_todoist(
                 final_menu_df=final_menu_df, todoist_helper=todoist_helper
             )

--- a/sous-chef/sous_chef/menu/create_menu/create_menu.py
+++ b/sous-chef/sous_chef/menu/create_menu/create_menu.py
@@ -26,7 +26,7 @@ class Menu(MenuFromFixedTemplate):
 
     def finalize_menu_to_external_services(self):
         self.load_final_menu()
-        self.save_with_menu_historian()
+        self.menu_historian.add_current_menu_to_history(self.dataframe)
 
         if self.config.menu.run_mode.with_todoist:
             todoist_helper = TodoistHelper(self.config.api.todoist)

--- a/sous-chef/sous_chef/menu/create_menu/models.py
+++ b/sous-chef/sous_chef/menu/create_menu/models.py
@@ -1,0 +1,96 @@
+from typing import Optional
+
+import pandas as pd
+import pandera as pa
+from pandera.typing import Series
+from sous_chef.date.get_due_date import MealTime, Weekday
+
+from utilities.extended_enum import ExtendedEnum, ExtendedIntEnum
+
+
+class TypeProcessOrder(ExtendedIntEnum):
+    recipe = 0
+    ingredient = 1
+    filter = 2
+    tag = 3
+    category = 4
+
+
+class RandomSelectType(ExtendedEnum):
+    rated = "rated"
+    unrated = "unrated"
+    either = "either"
+
+
+class Season(ExtendedEnum):
+    any = "0_any"
+    winter = "1_winter"
+    spring = "2_spring"
+    summer = "3_summer"
+    fall = "4_fall"
+
+
+class BasicMenuSchema(pa.SchemaModel):
+    # TODO replace all panderas with pydantic & create own validator with
+    #  dataframe returned, as no default functions & coerce is poorly made
+    weekday: Series[str] = pa.Field(isin=Weekday.name_list("capitalize"))
+    meal_time: Series[str] = pa.Field(isin=MealTime.name_list("lower"))
+    type: Series[str] = pa.Field(isin=TypeProcessOrder.name_list())
+    eat_factor: Series[float] = pa.Field(
+        ge=0, default=0, nullable=False, coerce=True
+    )
+    eat_unit: Series[str] = pa.Field(nullable=True)
+    freeze_factor: Series[float] = pa.Field(
+        ge=0, default=0, nullable=False, coerce=True
+    )
+    defrost: Series[str] = pa.Field(
+        isin=["Y", "N"], default="N", nullable=False, coerce=True
+    )
+    item: Series[str]
+
+    class Config:
+        strict = True
+        coerce = True
+
+
+class InProgressSchema(BasicMenuSchema):
+    selection: Series[str] = pa.Field(
+        isin=RandomSelectType.name_list(), nullable=True
+    )
+    prep_day: Optional[Series[float]] = pa.Field(
+        ge=0, lt=7, default=0, nullable=False, coerce=True
+    )
+    override_check: Series[str] = pa.Field(
+        isin=["Y", "N"], default="N", nullable=False, coerce=True
+    )
+
+
+class AllMenuSchema(InProgressSchema):
+    menu: Series[int] = pa.Field(ge=0, nullable=False)
+    season: Series[str] = pa.Field(isin=Season.value_list(), nullable=False)
+
+
+class TimeSchema(pa.SchemaModel):
+    cook_datetime: Optional[Series[pd.DatetimeTZDtype]] = pa.Field(
+        dtype_kwargs={"unit": "ns", "tz": "UTC"}, coerce=True
+    )
+    prep_datetime: Series[pd.DatetimeTZDtype] = pa.Field(
+        dtype_kwargs={"unit": "ns", "tz": "UTC"}, coerce=True, nullable=False
+    )
+
+
+class LoadedMenuSchema(InProgressSchema, TimeSchema):
+    pass
+
+
+class TmpMenuSchema(BasicMenuSchema, TimeSchema):
+    # override as should be replaced with one of these
+    type: Series[str] = pa.Field(isin=["ingredient", "recipe"])
+    time_total: Series[pd.Timedelta] = pa.Field(nullable=False, coerce=True)
+    # manual ingredients lack these
+    rating: Series[float] = pa.Field(nullable=True, coerce=True)
+    uuid: Series[str] = pa.Field(nullable=True)
+
+    class Config:
+        strict = True
+        coerce = True

--- a/sous-chef/sous_chef/menu/main.py
+++ b/sous-chef/sous_chef/menu/main.py
@@ -15,7 +15,6 @@ from sous_chef.rtk.read_write_rtk import RtkService
 from structlog import get_logger
 
 from utilities.api.gsheets_api import GsheetsHelper
-from utilities.api.todoist_api import TodoistHelper
 
 ABS_FILE_PATH = Path(__file__).absolute().parent
 FILE_LOGGER = get_logger(__name__)
@@ -51,13 +50,7 @@ def run_menu(config: DictConfig):
     if config.menu.create_menu.input_method == "fixed":
         menu.finalize_fixed_menu()
     elif config.menu.create_menu.input_method == "final":
-        menu.load_final_menu()
-        menu.save_with_menu_historian()
-
-        if config.menu.run_mode.with_todoist:
-            todoist_helper = TodoistHelper(config.api.todoist)
-            menu.upload_menu_to_todoist(todoist_helper)
-
+        menu.finalize_menu_to_external_services()
     return menu.dataframe
 
 
@@ -65,7 +58,6 @@ def run_menu(config: DictConfig):
     config_path="../../config/", config_name="menu_main", version_base=None
 )
 def main(config: DictConfig):
-
     if config.random.seed is None:
         config.random.seed = datetime.now().timestamp()
     config.random.seed = int(config.random.seed)

--- a/sous-chef/sous_chef/menu/main.py
+++ b/sous-chef/sous_chef/menu/main.py
@@ -40,7 +40,6 @@ def run_menu(config: DictConfig):
 
     recipe_book = RecipeBook(config.recipe_book)
 
-    # TODO move manual method here
     menu = Menu(
         config=config.menu.create_menu,
         due_date_formatter=due_date_formatter,

--- a/sous-chef/sous_chef/menu/main.py
+++ b/sous-chef/sous_chef/menu/main.py
@@ -51,7 +51,9 @@ def run_menu(config: DictConfig):
         menu.finalize_fixed_menu()
         return menu.dataframe
     elif config.menu.create_menu.input_method == "final":
-        return menu.finalize_menu_to_external_services()
+        return menu.finalize_menu_to_external_services(
+            config_todoist=config.api.todoist
+        )
 
 
 @hydra.main(

--- a/sous-chef/sous_chef/menu/main.py
+++ b/sous-chef/sous_chef/menu/main.py
@@ -49,9 +49,9 @@ def run_menu(config: DictConfig):
     )
     if config.menu.create_menu.input_method == "fixed":
         menu.finalize_fixed_menu()
+        return menu.dataframe
     elif config.menu.create_menu.input_method == "final":
-        menu.finalize_menu_to_external_services()
-    return menu.dataframe
+        return menu.finalize_menu_to_external_services()
 
 
 @hydra.main(

--- a/sous-chef/sous_chef/menu/record_menu_history.py
+++ b/sous-chef/sous_chef/menu/record_menu_history.py
@@ -4,8 +4,10 @@ from typing import List
 
 import pandas as pd
 import pandera as pa
+from menu.create_menu._menu_basic import TmpMenuSchema
 from omegaconf import DictConfig
 from pandera.typing import DataFrame, Series
+from pandera.typing.common import DataFrameBase
 from structlog import get_logger
 
 from utilities.api.gsheets_api import GsheetsHelper
@@ -73,7 +75,9 @@ class MenuHistorian:
             self.dataframe.cook_datetime < self.current_menu_start_date
         ]
 
-    def add_current_menu_to_history(self, current_menu: DataFrame):
+    def add_current_menu_to_history(
+        self, current_menu: DataFrameBase[TmpMenuSchema]
+    ):
         menu_recipes = current_menu[current_menu["type"] == "recipe"][
             self.columns
         ]

--- a/sous-chef/sous_chef/menu/record_menu_history.py
+++ b/sous-chef/sous_chef/menu/record_menu_history.py
@@ -4,10 +4,10 @@ from typing import List
 
 import pandas as pd
 import pandera as pa
-from menu.create_menu._menu_basic import TmpMenuSchema
 from omegaconf import DictConfig
 from pandera.typing import DataFrame, Series
 from pandera.typing.common import DataFrameBase
+from sous_chef.menu.create_menu.models import TmpMenuSchema
 from structlog import get_logger
 
 from utilities.api.gsheets_api import GsheetsHelper

--- a/sous-chef/tests/data/util_data.py
+++ b/sous-chef/tests/data/util_data.py
@@ -3,11 +3,8 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 from pandera.typing.common import DataFrameBase
-from sous_chef.menu.create_menu._menu_basic import (
-    AllMenuSchema,
-    TmpMenuSchema,
-    validate_menu_schema,
-)
+from sous_chef.menu.create_menu._menu_basic import validate_menu_schema
+from sous_chef.menu.create_menu.models import AllMenuSchema, TmpMenuSchema
 
 abs_path = Path(__file__).parent.absolute()
 

--- a/sous-chef/tests/e2e_tests/util.py
+++ b/sous-chef/tests/e2e_tests/util.py
@@ -35,4 +35,4 @@ class Base:
         create_menu.fixed.basic_number = 0
         create_menu.fixed.menu_number = 1
         create_menu.todoist.project_name = PROJECT
-        create_menu["todoist"]["is_active"] = True
+        create_menu.todoist.is_active = True

--- a/sous-chef/tests/e2e_tests/util.py
+++ b/sous-chef/tests/e2e_tests/util.py
@@ -35,3 +35,4 @@ class Base:
         create_menu.fixed.basic_number = 0
         create_menu.fixed.menu_number = 1
         create_menu.todoist.project_name = PROJECT
+        create_menu["todoist"]["is_active"] = True

--- a/sous-chef/tests/integration_tests/menu/create_menu/test_create_menu_integration.py
+++ b/sous-chef/tests/integration_tests/menu/create_menu/test_create_menu_integration.py
@@ -73,8 +73,8 @@ class TestMenu:
     ):
         menu_config.fixed.menu_number = 1
         menu_with_recipe_book.finalize_fixed_menu()
-        menu_with_recipe_book.load_final_menu()
-        assert_equal_dataframe(menu_with_recipe_book.dataframe, get_tmp_menu())
+        final_menu_df = menu_with_recipe_book._load_final_menu()
+        assert_equal_dataframe(final_menu_df, get_tmp_menu())
 
     @staticmethod
     def test_finalize_fixed_menu_fails_for_record_exception(
@@ -128,7 +128,9 @@ class TestMenu:
     @staticmethod
     @pytest.mark.todoist
     def test__upload_menu_to_todoist(menu, todoist_helper):
-        menu.load_final_menu()
-        menu._upload_menu_to_todoist(todoist_helper=todoist_helper)
+        final_menu_df = menu._load_final_menu()
+        menu._upload_menu_to_todoist(
+            final_menu_df=final_menu_df, todoist_helper=todoist_helper
+        )
         with patch("builtins.input", side_effect=[YesNoChoices.yes.value]):
             todoist_helper.delete_all_items_in_project(project=PROJECT)

--- a/sous-chef/tests/integration_tests/menu/create_menu/test_create_menu_integration.py
+++ b/sous-chef/tests/integration_tests/menu/create_menu/test_create_menu_integration.py
@@ -127,8 +127,8 @@ class TestMenu:
 
     @staticmethod
     @pytest.mark.todoist
-    def test_upload_menu_to_todoist(menu, todoist_helper):
+    def test__upload_menu_to_todoist(menu, todoist_helper):
         menu.load_final_menu()
-        menu.upload_menu_to_todoist(todoist_helper)
+        menu._upload_menu_to_todoist(todoist_helper=todoist_helper)
         with patch("builtins.input", side_effect=[YesNoChoices.yes.value]):
             todoist_helper.delete_all_items_in_project(project=PROJECT)

--- a/sous-chef/tests/integration_tests/menu/create_menu/test_create_menu_integration.py
+++ b/sous-chef/tests/integration_tests/menu/create_menu/test_create_menu_integration.py
@@ -105,9 +105,9 @@ class TestMenu:
 
     @staticmethod
     def test_get_menu_for_grocery_list_fails_for_record_exception(
-        menu, mock_recipe_book
+        menu, menu_config, mock_recipe_book, capsys
     ):
-        menu.tuple_log_exception = (RecipeNotFoundError,)
+        menu_config.errors["recipe_not_found"] = "log"
         mock_recipe_book.get_recipe_by_title.side_effect = RecipeNotFoundError(
             recipe_title="dummy", search_results="dummy"
         )
@@ -120,9 +120,10 @@ class TestMenu:
             str(error.value)
             == "[menu had errors] will not send to grocery list until fixed"
         )
-        assert set(menu.record_exception) == {
+        assert (
             "[recipe not found] recipe=dummy search_results=[dummy]"
-        }
+            in capsys.readouterr().out
+        )
 
     @staticmethod
     @pytest.mark.todoist

--- a/sous-chef/tests/unit_tests/conftest.py
+++ b/sous-chef/tests/unit_tests/conftest.py
@@ -7,7 +7,7 @@ import pandas as pd
 import pytest
 from hydra import compose, initialize
 from pandera.typing.common import DataFrameBase
-from sous_chef.menu.create_menu._menu_basic import BasicMenuSchema
+from sous_chef.menu.create_menu.models import BasicMenuSchema
 from sous_chef.menu.record_menu_history import MenuHistorian
 from tests.conftest import FROZEN_DATETIME
 from tests.data.util_data import get_all_menus

--- a/sous-chef/tests/unit_tests/menu/create_menu/conftest.py
+++ b/sous-chef/tests/unit_tests/menu/create_menu/conftest.py
@@ -9,14 +9,14 @@ from hydra import compose, initialize
 from pandera.typing.common import DataFrameBase
 from pint import Unit
 from sous_chef.formatter.units import unit_registry
-from sous_chef.menu.create_menu._menu_basic import (
+from sous_chef.menu.create_menu._menu_basic import validate_menu_schema
+from sous_chef.menu.create_menu.create_menu import Menu
+from sous_chef.menu.create_menu.models import (
     AllMenuSchema,
     LoadedMenuSchema,
     Season,
     TmpMenuSchema,
-    validate_menu_schema,
 )
-from sous_chef.menu.create_menu.create_menu import Menu
 from tests.conftest import FROZEN_DATE
 
 

--- a/sous-chef/tests/unit_tests/menu/create_menu/test__for_grocery_list.py
+++ b/sous-chef/tests/unit_tests/menu/create_menu/test__for_grocery_list.py
@@ -1,0 +1,95 @@
+import pandas as pd
+import pytest
+from sous_chef.formatter.ingredient.format_ingredient import Ingredient
+from sous_chef.formatter.units import unit_registry
+from sous_chef.menu.create_menu._for_grocery_list import (
+    MenuForGroceryList,
+    MenuIngredient,
+    MenuRecipe,
+)
+from tests.unit_tests.util import create_recipe
+
+
+@pytest.fixture
+def menu_for_grocery_list(
+    menu_config,
+    mock_ingredient_formatter,
+    mock_recipe_book,
+):
+    return MenuForGroceryList(
+        config_errors=menu_config.errors,
+        # not needed in unit tests as row given explicitly
+        final_menu_df=pd.DataFrame(),
+        ingredient_formatter=mock_ingredient_formatter,
+        recipe_book=mock_recipe_book,
+    )
+
+
+class TestForGroceryList:
+    @staticmethod
+    @pytest.mark.parametrize(
+        "quantity,pint_unit,item", [(1.0, unit_registry.cup, "frozen broccoli")]
+    )
+    def test__retrieve_manual_menu_ingredient(
+        menu_for_grocery_list,
+        menu_builder,
+        mock_ingredient_formatter,
+        quantity,
+        pint_unit,
+        item,
+    ):
+        row = menu_builder.create_loaded_menu_row(
+            eat_factor=quantity,
+            eat_unit=pint_unit,
+            item=item,
+            item_type="ingredient",
+        ).squeeze()
+
+        ingredient = Ingredient(
+            quantity=quantity, pint_unit=pint_unit, item=item
+        )
+        mock_ingredient_formatter.format_manual_ingredient.return_value = (
+            ingredient
+        )
+        result = menu_for_grocery_list._retrieve_manual_menu_ingredient(row)
+        assert (
+            result.__dict__
+            == MenuIngredient(
+                ingredient=ingredient,
+                from_recipe="manual",
+                for_day=row["prep_datetime"],
+            ).__dict__
+        )
+
+    @staticmethod
+    @pytest.mark.parametrize(
+        "recipe_title",
+        ["grilled cheese", "garlic aioli"],
+    )
+    def test__retrieve_menu_recipe(
+        menu_for_grocery_list,
+        menu_builder,
+        mock_recipe_book,
+        recipe_title,
+    ):
+        row = menu_builder.create_loaded_menu_row(
+            item=recipe_title,
+            item_type="recipe",
+        ).squeeze()
+        recipe_with_recipe_title = create_recipe(title=recipe_title)
+        mock_recipe_book.get_recipe_by_title.return_value = (
+            recipe_with_recipe_title
+        )
+
+        result = menu_for_grocery_list._retrieve_menu_recipe(row)
+
+        assert (
+            result.__dict__
+            == MenuRecipe(
+                recipe=recipe_with_recipe_title,
+                eat_factor=row["eat_factor"],
+                freeze_factor=0.0,
+                for_day=row["prep_datetime"],
+                from_recipe=row["item"],
+            ).__dict__
+        )

--- a/sous-chef/tests/unit_tests/menu/create_menu/test__for_todoist.py
+++ b/sous-chef/tests/unit_tests/menu/create_menu/test__for_todoist.py
@@ -17,7 +17,7 @@ def menu_for_todoist(
 
     return MenuForTodoist(
         config=menu_config.todoist,
-        dataframe=mock_all_menus_df,
+        final_menu_df=mock_all_menus_df,
         due_date_formatter=frozen_due_datetime_formatter,
         todoist_helper=mock_todoist_helper,
     )

--- a/sous-chef/tests/unit_tests/menu/create_menu/test__from_fixed_template.py
+++ b/sous-chef/tests/unit_tests/menu/create_menu/test__from_fixed_template.py
@@ -6,7 +6,8 @@ from freezegun import freeze_time
 from sous_chef.formatter.ingredient.format_ingredient import Ingredient
 from sous_chef.formatter.units import unit_registry
 from sous_chef.menu.create_menu._from_fixed_template import FixedTemplates
-from sous_chef.menu.create_menu._menu_basic import MenuFutureError, Season
+from sous_chef.menu.create_menu._menu_basic import MenuFutureError
+from sous_chef.menu.create_menu.models import Season
 from sous_chef.menu.record_menu_history import MenuHistoryError
 from tests.conftest import FROZEN_DATE
 from tests.unit_tests.util import create_recipe

--- a/sous-chef/tests/unit_tests/menu/create_menu/test_create_menu.py
+++ b/sous-chef/tests/unit_tests/menu/create_menu/test_create_menu.py
@@ -2,12 +2,7 @@ import numpy as np
 import pandas as pd
 import pytest
 from sous_chef.date.get_due_date import Weekday
-from sous_chef.formatter.ingredient.format_ingredient import Ingredient
 from sous_chef.formatter.units import unit_registry
-from sous_chef.menu.create_menu._for_grocery_list import (
-    MenuIngredient,
-    MenuRecipe,
-)
 from sous_chef.menu.create_menu._menu_basic import get_weekday_from_short
 from tests.unit_tests.util import create_recipe
 
@@ -166,69 +161,6 @@ class TestMenu:
         assert log.events == []
         assert out == ""
         assert err == ""
-
-    @staticmethod
-    @pytest.mark.parametrize(
-        "quantity,pint_unit,item", [(1.0, unit_registry.cup, "frozen broccoli")]
-    )
-    def test__retrieve_manual_menu_ingredient(
-        menu, menu_builder, mock_ingredient_formatter, quantity, pint_unit, item
-    ):
-        row = menu_builder.create_loaded_menu_row(
-            eat_factor=quantity,
-            eat_unit=pint_unit,
-            item=item,
-            item_type="ingredient",
-        ).squeeze()
-
-        ingredient = Ingredient(
-            quantity=quantity, pint_unit=pint_unit, item=item
-        )
-        mock_ingredient_formatter.format_manual_ingredient.return_value = (
-            ingredient
-        )
-        result = menu._retrieve_manual_menu_ingredient(row)
-        assert (
-            result.__dict__
-            == MenuIngredient(
-                ingredient=ingredient,
-                from_recipe="manual",
-                for_day=row["prep_datetime"],
-            ).__dict__
-        )
-
-    @staticmethod
-    @pytest.mark.parametrize(
-        "recipe_title",
-        ["grilled cheese", "garlic aioli"],
-    )
-    def test__retrieve_menu_recipe(
-        menu,
-        menu_builder,
-        mock_recipe_book,
-        recipe_title,
-    ):
-        row = menu_builder.create_loaded_menu_row(
-            item=recipe_title,
-            item_type="recipe",
-        ).squeeze()
-        recipe_with_recipe_title = create_recipe(title=recipe_title)
-        mock_recipe_book.get_recipe_by_title.return_value = (
-            recipe_with_recipe_title
-        )
-
-        result = menu._retrieve_menu_recipe(row)
-
-        assert (
-            result.__dict__
-            == MenuRecipe(
-                recipe=recipe_with_recipe_title,
-                eat_factor=row["eat_factor"],
-                freeze_factor=0.0,
-                for_day=row["prep_datetime"],
-                from_recipe=row["item"],
-            ).__dict__
-        )
 
 
 class TestGetWeekdayFromShort:


### PR DESCRIPTION
This is the 2nd of many pull requests to decouple the menu inheritance from the underlying subclasses. In this case, we want to make _for_grocery_list's usage more explicit & clearer what is used.