### PR TITLE
Introduce general rules in extra yaml to allow more flexible remappings

### DIFF
--- a/banking-helpers/banking_helpers/app.py
+++ b/banking-helpers/banking_helpers/app.py
@@ -53,6 +53,12 @@ def main() -> None:
     output_config: DictConfig = OmegaConf.load(
         config_dir / "output_format.yaml"
     )
+    rules_config_path: Path = config_dir / "rules.yaml"
+    rules_config: DictConfig | None = (
+        OmegaConf.load(rules_config_path)
+        if rules_config_path.exists()
+        else None
+    )
 
     # Get available banks
     banks: dict[str, str] = get_bank_configs(config_dir)
@@ -90,6 +96,7 @@ def main() -> None:
                     bank_config=bank_config,
                     output_config=output_config,
                     date_format=main_config.date_format,
+                    rules_config=rules_config,
                 )
 
                 prepared_df: pd.DataFrame = processor.process(csv_content)

--- a/banking-helpers/banking_helpers/cli.py
+++ b/banking-helpers/banking_helpers/cli.py
@@ -58,10 +58,15 @@ def run(
         sys.exit(1)
 
     bank_cfg: DictConfig = OmegaConf.load(bank_cfg_path)
+    rules_cfg_path: Path = config_dir / "rules.yaml"
+    rules_cfg: DictConfig | None = (
+        OmegaConf.load(rules_cfg_path) if rules_cfg_path.exists() else None
+    )
     processor: CSVProcessor = CSVProcessor(
         bank_config=bank_cfg,
         output_config=output_cfg,
         date_format=main_cfg.date_format,
+        rules_config=rules_cfg,
     )
 
     csv_bytes: bytes = csv_path.read_bytes()

--- a/banking-helpers/banking_helpers/processor.py
+++ b/banking-helpers/banking_helpers/processor.py
@@ -1,6 +1,9 @@
 """CSV processor for banking transactions."""
 
 import io
+import re
+import warnings
+from typing import Optional
 
 import pandas as pd
 import pandera.pandas as pa
@@ -13,7 +16,7 @@ from banking_helpers.utils import (
     parse_amount,
     parse_date,
 )
-from omegaconf import DictConfig
+from omegaconf import DictConfig, OmegaConf
 
 
 class CSVProcessor:
@@ -24,6 +27,7 @@ class CSVProcessor:
         bank_config: DictConfig,
         output_config: DictConfig,
         date_format: str,
+        rules_config: Optional[DictConfig] = None,
     ) -> None:
         """
         Initialize processor with configurations.
@@ -32,11 +36,19 @@ class CSVProcessor:
             bank_config: Bank-specific config (column mappings, formats, etc.)
             output_config: Output format configuration (column definitions)
             date_format: Output date format string
+            rules_config: Optional shared rules config (rules.yaml). When provided,
+                rules are applied as a post-processing step after all columns are
+                parsed. Bank-level ``extra_rules`` (if any) take priority.
         """
         self.bank_config: DictConfig = bank_config
         self.output_config: DictConfig = output_config
-        self.schema = self._build_schema()
+        self.rules_config: Optional[DictConfig] = rules_config
         self.date_format: str = date_format
+        self.schema = self._build_schema()
+        # Pre-compile rules once; invalid regexes are warned and skipped here.
+        self._compiled_rules: list[tuple[re.Pattern, dict]] = (
+            self._build_compiled_rules()
+        )
 
     def process(self, csv_content: bytes) -> pd.DataFrame:
         """
@@ -81,6 +93,15 @@ class CSVProcessor:
         output_df = pd.DataFrame(output_data)
         if "Date" in output_df.columns:
             output_df = self._sort_by_date(output_df, col="Date")
+
+        # Reset index so label == positional index (required for _apply_rules)
+        output_df = output_df.reset_index(drop=True)
+
+        # Apply shared + bank-level pattern rules as a post-processing step
+        output_df = self._apply_rules(output_df)
+
+        # Apply bank-level value remappings (e.g. joint → to be split)
+        output_df = self._apply_remap_values(output_df)
 
         # Validate output DataFrame against schema
         self._validate_output(output_df)
@@ -271,20 +292,17 @@ class CSVProcessor:
     def _build_normalized_row_texts(
         df: pd.DataFrame, source_columns: list[str]
     ) -> list[str]:
-        """Combine and normalize all source text columns row-wise."""
-        return [
-            normalize_combined_text(
-                " ".join(
-                    (
-                        str(df[col].iloc[idx])
-                        if pd.notna(df[col].iloc[idx])
-                        else ""
-                    )
-                    for col in source_columns
-                )
-            )
-            for idx in range(len(df))
-        ]
+        """Combine and normalize all source text columns row-wise (vectorized)."""
+        combined: pd.Series = (
+            df[source_columns].fillna("").astype(str).agg(" ".join, axis=1)
+        )
+        return (
+            combined.str.lower()
+            .str.replace(r"[\n\t]", " ", regex=True)
+            .str.split()
+            .str.join(" ")
+            .tolist()
+        )
 
     def _parse_string_column(
         self, df: pd.DataFrame, mapping: DictConfig, source_columns: list[str]
@@ -327,6 +345,139 @@ class CSVProcessor:
             or default_category
             for combined_text in combined_texts
         ]
+
+    def _build_compiled_rules(self) -> list[tuple[re.Pattern, dict]]:
+        """
+        Pre-compile regex patterns from bank extra_rules + global rules.
+
+        Extra rules (bank config) are prepended and evaluated first (higher
+        priority). Invalid regex patterns emit a SyntaxWarning and are skipped.
+        Called once at construction time so errors surface early.
+
+        Returns:
+            List of (compiled_pattern, rule_dict) in evaluation order.
+        """
+        raw_extra = self.bank_config.get("extra_rules")
+        extra_rules: list = (
+            list(OmegaConf.to_container(raw_extra, resolve=True))
+            if OmegaConf.is_config(raw_extra)
+            else list(raw_extra) if raw_extra else []
+        )
+        raw_global = (
+            self.rules_config.get("rules") if self.rules_config else None
+        )
+        global_rules: list = (
+            list(OmegaConf.to_container(raw_global, resolve=True))
+            if OmegaConf.is_config(raw_global)
+            else list(raw_global) if raw_global else []
+        )
+
+        compiled: list[tuple[re.Pattern, dict]] = []
+        for rule in extra_rules + global_rules:
+            regex_str: str = rule.get("regex", "")
+            if not regex_str:
+                continue
+            try:
+                # Cell text is already lowercased before matching
+                compiled.append((re.compile(regex_str), rule))
+            except re.error as exc:
+                warnings.warn(
+                    f"Invalid regex in rule '{rule.get('name', '')}': {exc}",
+                    SyntaxWarning,
+                    stacklevel=2,
+                )
+        return compiled
+
+    def _apply_rules(self, df: pd.DataFrame) -> pd.DataFrame:
+        """
+        Apply pre-compiled pattern rules as a post-processing step.
+
+        Bank-level extra_rules (higher priority) are prepended to global rules.
+        First matching rule per row wins; remaining rules for that row are skipped.
+
+        When ``shorten_description_on_rule_match: true`` is set in the bank
+        config, Description is also replaced with the matched text fragment.
+
+        Args:
+            df: Output DataFrame (already sorted, index reset).
+
+        Returns:
+            DataFrame with rule-derived column values applied in-place.
+        """
+        if not self._compiled_rules:
+            return df
+
+        shorten_description: bool = bool(
+            self.bank_config.get("shorten_description_on_rule_match", False)
+        )
+
+        for idx in range(len(df)):
+            for pattern, rule in self._compiled_rules:
+                match_col: str = rule.get("match_on", "Description")
+                if match_col not in df.columns:
+                    continue
+
+                cell_value = df.at[idx, match_col]
+                if not isinstance(cell_value, str):
+                    continue
+
+                match = pattern.search(cell_value.lower())
+                if match:
+                    for col, value in (rules := rule.get("set") or {}).items():
+                        if col in df.columns:
+                            df.at[idx, col] = value
+                    # rules take precedence over generic shortening
+                    if (
+                        shorten_description
+                        and ("Description" in df.columns)
+                        and ("Description" not in rules.keys())
+                    ):
+                        df.at[idx, "Description"] = normalize_combined_text(
+                            match.group(0)
+                        )
+                    break  # First match wins; skip remaining rules for this row
+
+        return df
+
+    def _apply_remap_values(self, df: pd.DataFrame) -> pd.DataFrame:
+        """
+        Apply bank-level value remappings as a final post-processing step.
+
+        Reads ``remap_values`` from the bank config — a mapping of
+        ``{column: {old_value: new_value}}``.  Every cell in *column* whose
+        value equals *old_value* (exact, case-sensitive) is replaced with
+        *new_value*.  The remapping is applied after all rules, so it catches
+        values set both by literals and by rule ``set`` directives.
+
+        Example bank config entry::
+
+            remap_values:
+              Payment:
+                joint: "to be split"
+
+        Args:
+            df: Output DataFrame after rules have been applied.
+
+        Returns:
+            DataFrame with remapped values applied in-place.
+        """
+        raw = self.bank_config.get("remap_values")
+        if not raw:
+            return df
+
+        remap: dict = (
+            OmegaConf.to_container(raw, resolve=True)
+            if OmegaConf.is_config(raw)
+            else dict(raw)
+        )
+
+        for col, value_map in remap.items():
+            if col not in df.columns:
+                continue
+            for old_value, new_value in value_map.items():
+                df[col] = df[col].replace(old_value, new_value)
+
+        return df
 
     @staticmethod
     def _sort_by_date(df: pd.DataFrame, col: str = "Date") -> pd.DataFrame:

--- a/banking-helpers/tests/conftest.py
+++ b/banking-helpers/tests/conftest.py
@@ -4,6 +4,89 @@ import pytest
 from omegaconf import OmegaConf
 
 
+@pytest.fixture
+def rules_config():
+    """Minimal shared rules config for testing global rule application."""
+    return OmegaConf.create(
+        {
+            "rules": [
+                {
+                    "name": "groceries",
+                    "regex": "rewe|edeka",
+                    "match_on": "Description",
+                    "set": {"Category": "groceries"},
+                },
+                {
+                    "name": "fun",
+                    "regex": "spotify|netflix",
+                    "match_on": "Description",
+                    "set": {"Category": "fun"},
+                },
+                {
+                    # Rule that sets multiple columns at once
+                    "name": "rent",
+                    "regex": "miete|rent",
+                    "match_on": "Description",
+                    "set": {"Category": "rent", "Payment": "direct"},
+                },
+            ]
+        }
+    )
+
+
+@pytest.fixture
+def rules_bank_config():
+    """
+    Bank config that uses literal Category (relies entirely on rules for
+    category assignment, matching the post-migration bank config pattern).
+    """
+    return OmegaConf.create(
+        {
+            "bank_name": "Test Bank",
+            "date_format": "DD.MM.YY",
+            "delimiter": ";",
+            "skip_rows": 0,
+            "extra_rules": [],
+            "column_mappings": {
+                "Date": {
+                    "source_columns": ["Date"],
+                    "parser": "date",
+                },
+                "Category": {
+                    "parser": "literal",
+                    "value": "household",
+                },
+                "Payment": {
+                    "parser": "literal",
+                    "value": "joint",
+                },
+                "Payer": {
+                    "parser": "literal",
+                    "value": "john",
+                },
+                "Benefiter": {
+                    "parser": "literal",
+                    "value": "shared",
+                },
+                "Amount": {
+                    "source_columns": ["Amount"],
+                    "parser": "amount",
+                    "positive_is": "debit",
+                    "decimal_separator": ".",
+                },
+                "To-update": {
+                    "parser": "literal",
+                    "value": "",
+                },
+                "Description": {
+                    "source_columns": ["Description"],
+                    "parser": "string",
+                },
+            },
+        }
+    )
+
+
 @pytest.fixture(scope="session")
 def test_data_dir():
     """Fixture for test data directory path."""

--- a/banking-helpers/tests/unit/test_rules.py
+++ b/banking-helpers/tests/unit/test_rules.py
@@ -1,0 +1,395 @@
+"""Unit tests for the _apply_rules post-processing step in CSVProcessor."""
+
+import warnings
+
+import pytest
+from banking_helpers.processor import CSVProcessor
+from omegaconf import OmegaConf
+
+
+@pytest.fixture
+def processor(rules_bank_config, output_config, rules_config):
+    """CSVProcessor with rules_config wired in."""
+    return CSVProcessor(
+        rules_bank_config,
+        output_config,
+        "YYYY-MM-DD",
+        rules_config=rules_config,
+    )
+
+
+class TestApplyRulesBasic:
+    """Core rule-matching behaviour."""
+
+    @pytest.mark.parametrize(
+        "description,expected_category",
+        [
+            ("REWE MARKT GMBH", "groceries"),
+            ("EDEKA CENTER BERLIN", "groceries"),
+            ("SPOTIFY PREMIUM", "fun"),
+            ("NETFLIX MONTHLY", "fun"),
+            ("MIETE JANUAR", "rent"),
+            ("UNKNOWN STORE", "household"),  # no match → literal default
+        ],
+    )
+    def test_rule_sets_category(
+        self, processor, description, expected_category
+    ):
+        """Global rules correctly assign Category for known and unknown entries."""
+        csv_content = f"Date;Description\n01.01.26;{description}".encode()
+        result = processor.process(csv_content)
+        assert result["Category"].iloc[0] == expected_category
+
+    def test_first_rule_wins(self, rules_bank_config, output_config):
+        """When multiple rules match, only the first one is applied."""
+        rules = OmegaConf.create(
+            {
+                "rules": [
+                    {
+                        "name": "first",
+                        "regex": "rewe",
+                        "match_on": "Description",
+                        "set": {"Category": "groceries"},
+                    },
+                    {
+                        "name": "second",
+                        "regex": "rewe|edeka",
+                        "match_on": "Description",
+                        "set": {"Category": "other"},
+                    },
+                ]
+            }
+        )
+        processor = CSVProcessor(
+            rules_bank_config, output_config, "YYYY-MM-DD", rules_config=rules
+        )
+        result = processor.process(b"Date;Description\n01.01.26;REWE MARKT")
+        assert result["Category"].iloc[0] == "groceries"
+
+    def test_rule_sets_multiple_columns(self, processor):
+        """A single rule can overwrite more than one output column at once."""
+        result = processor.process(b"Date;Description\n01.01.26;MIETE JANUAR")
+        assert result["Category"].iloc[0] == "rent"
+        assert result["Payment"].iloc[0] == "direct"
+
+    def test_multiple_rows_matched_independently(self, processor):
+        """Each row is evaluated against rules independently."""
+        csv_content = (
+            b"Date;Description\n"
+            b"01.01.26;REWE MARKT\n"
+            b"02.01.26;SPOTIFY PREMIUM\n"
+            b"03.01.26;UNKNOWN STORE"
+        )
+        result = processor.process(csv_content)
+        assert result["Category"].tolist() == ["groceries", "fun", "household"]
+
+    def test_no_rules_config_keeps_defaults(
+        self, rules_bank_config, output_config
+    ):
+        """Without a rules_config, Category stays at the literal default."""
+        processor = CSVProcessor(
+            rules_bank_config, output_config, "YYYY-MM-DD", rules_config=None
+        )
+        result = processor.process(b"Date;Description\n01.01.26;REWE MARKT")
+        assert result["Category"].iloc[0] == "household"
+
+
+class TestApplyRulesPriority:
+    """Priority: extra_rules (bank-level) beats global rules."""
+
+    def test_extra_rules_override_global_rules(
+        self, rules_bank_config, output_config, rules_config
+    ):
+        """Bank extra_rules map 'rewe' → takeout, overriding the global groceries rule."""
+        rules_bank_config.extra_rules = [
+            {
+                "name": "bank_override",
+                "regex": "rewe",
+                "match_on": "Description",
+                "set": {"Category": "takeout"},
+            }
+        ]
+        processor = CSVProcessor(
+            rules_bank_config,
+            output_config,
+            "YYYY-MM-DD",
+            rules_config=rules_config,
+        )
+        result = processor.process(b"Date;Description\n01.01.26;REWE MARKT")
+        assert result["Category"].iloc[0] == "takeout"
+
+    def test_global_rules_apply_when_no_extra_rule_matches(
+        self, rules_bank_config, output_config, rules_config
+    ):
+        """When extra_rules don't match, global rules still fire normally."""
+        rules_bank_config.extra_rules = [
+            {
+                "name": "bank_specific",
+                "regex": "hausbank",
+                "match_on": "Description",
+                "set": {"Category": "transit"},
+            }
+        ]
+        processor = CSVProcessor(
+            rules_bank_config,
+            output_config,
+            "YYYY-MM-DD",
+            rules_config=rules_config,
+        )
+        result = processor.process(b"Date;Description\n01.01.26;REWE MARKT")
+        # extra_rule did not match; global groceries rule fires
+        assert result["Category"].iloc[0] == "groceries"
+
+
+class TestApplyRulesShortenDescription:
+    """shorten_description_on_rule_match bank-level flag."""
+
+    def test_description_shortened_to_matched_text(
+        self, rules_bank_config, output_config, rules_config
+    ):
+        """When flag is set, Description is replaced with the matched keyword."""
+        rules_bank_config.shorten_description_on_rule_match = True
+        processor = CSVProcessor(
+            rules_bank_config,
+            output_config,
+            "YYYY-MM-DD",
+            rules_config=rules_config,
+        )
+        result = processor.process(
+            b"Date;Description\n01.01.26;REWE MARKT GMBH 1234"
+        )
+        assert result["Description"].iloc[0] == "rewe"
+        assert result["Category"].iloc[0] == "groceries"
+
+    def test_unmatched_row_description_unchanged(
+        self, rules_bank_config, output_config, rules_config
+    ):
+        """Rows without a matching rule keep their full description."""
+        rules_bank_config.shorten_description_on_rule_match = True
+        processor = CSVProcessor(
+            rules_bank_config,
+            output_config,
+            "YYYY-MM-DD",
+            rules_config=rules_config,
+        )
+        result = processor.process(
+            b"Date;Description\n01.01.26;UNKNOWN STORE XYZ"
+        )
+        assert result["Description"].iloc[0] == "unknown store xyz"
+
+    def test_flag_off_description_not_shortened(
+        self, rules_bank_config, output_config, rules_config
+    ):
+        """Without the flag, Description is never shortened even when a rule matches."""
+        # flag is absent (default) in rules_bank_config
+        processor = CSVProcessor(
+            rules_bank_config,
+            output_config,
+            "YYYY-MM-DD",
+            rules_config=rules_config,
+        )
+        result = processor.process(
+            b"Date;Description\n01.01.26;REWE MARKT GMBH 1234"
+        )
+        assert result["Description"].iloc[0] == "rewe markt gmbh 1234"
+        assert result["Category"].iloc[0] == "groceries"
+
+
+class TestApplyRulesEdgeCases:
+    """Robustness: invalid regexes, missing columns, empty rule lists."""
+
+    def test_invalid_regex_warns_and_falls_through_to_next_rule(
+        self, rules_bank_config, output_config
+    ):
+        """Invalid regex emits SyntaxWarning at construction time and is skipped;
+        subsequent valid rules still fire normally."""
+        rules = OmegaConf.create(
+            {
+                "rules": [
+                    {
+                        "name": "bad",
+                        "regex": "[unclosed",
+                        "match_on": "Description",
+                        "set": {"Category": "invalid"},
+                    },
+                    {
+                        "name": "good",
+                        "regex": "rewe",
+                        "match_on": "Description",
+                        "set": {"Category": "groceries"},
+                    },
+                ]
+            }
+        )
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            processor = CSVProcessor(
+                rules_bank_config,
+                output_config,
+                "YYYY-MM-DD",
+                rules_config=rules,
+            )
+            result = processor.process(b"Date;Description\n01.01.26;REWE MARKT")
+
+        assert result["Category"].iloc[0] == "groceries"
+        assert any(issubclass(w.category, SyntaxWarning) for w in caught)
+
+    def test_nonexistent_match_on_column_is_skipped(
+        self, rules_bank_config, output_config
+    ):
+        """A rule targeting a column that doesn't exist in output is silently ignored."""
+        rules = OmegaConf.create(
+            {
+                "rules": [
+                    {
+                        "name": "bad_col",
+                        "regex": "rewe",
+                        "match_on": "NonExistentColumn",
+                        "set": {"Category": "groceries"},
+                    }
+                ]
+            }
+        )
+        processor = CSVProcessor(
+            rules_bank_config, output_config, "YYYY-MM-DD", rules_config=rules
+        )
+        result = processor.process(b"Date;Description\n01.01.26;REWE MARKT")
+        # Rule skipped → default stays
+        assert result["Category"].iloc[0] == "household"
+
+    def test_empty_rules_list_no_change(self, rules_bank_config, output_config):
+        """An empty rules list leaves all values at their defaults."""
+        rules = OmegaConf.create({"rules": []})
+        processor = CSVProcessor(
+            rules_bank_config, output_config, "YYYY-MM-DD", rules_config=rules
+        )
+        result = processor.process(b"Date;Description\n01.01.26;REWE MARKT")
+        assert result["Category"].iloc[0] == "household"
+
+    def test_rule_with_empty_set_does_not_crash(
+        self, rules_bank_config, output_config
+    ):
+        """A rule with an empty set dict is a no-op and does not raise."""
+        rules = OmegaConf.create(
+            {
+                "rules": [
+                    {
+                        "name": "noop",
+                        "regex": "rewe",
+                        "match_on": "Description",
+                        "set": {},
+                    }
+                ]
+            }
+        )
+        processor = CSVProcessor(
+            rules_bank_config, output_config, "YYYY-MM-DD", rules_config=rules
+        )
+        result = processor.process(b"Date;Description\n01.01.26;REWE MARKT")
+        assert result["Category"].iloc[0] == "household"
+
+
+class TestRemapValues:
+    """remap_values bank-level config: post-rule value substitution."""
+
+    def test_literal_joint_remapped_to_to_be_split(
+        self, rules_bank_config, output_config
+    ):
+        """Payment 'joint' (set by literal) is remapped to 'to be split'."""
+        rules_bank_config.remap_values = {"Payment": {"joint": "to be split"}}
+        processor = CSVProcessor(rules_bank_config, output_config, "YYYY-MM-DD")
+        result = processor.process(b"Date;Description\n01.01.26;UNKNOWN STORE")
+        assert result["Payment"].iloc[0] == "to be split"
+
+    def test_rule_set_joint_remapped(self, rules_bank_config, output_config):
+        """Payment 'joint' set by a rule is also remapped."""
+        rules = OmegaConf.create(
+            {
+                "rules": [
+                    {
+                        "name": "force_joint",
+                        "regex": "rewe",
+                        "match_on": "Description",
+                        "set": {"Payment": "joint"},
+                    }
+                ]
+            }
+        )
+        rules_bank_config.remap_values = {"Payment": {"joint": "to be split"}}
+        processor = CSVProcessor(
+            rules_bank_config, output_config, "YYYY-MM-DD", rules_config=rules
+        )
+        result = processor.process(b"Date;Description\n01.01.26;REWE MARKT")
+        assert result["Payment"].iloc[0] == "to be split"
+
+    def test_non_matching_value_untouched(
+        self, rules_bank_config, output_config
+    ):
+        """Values that don't match a remap entry are left unchanged."""
+        rules_bank_config.column_mappings.Payment.value = "direct"
+        rules_bank_config.remap_values = {"Payment": {"joint": "to be split"}}
+        processor = CSVProcessor(rules_bank_config, output_config, "YYYY-MM-DD")
+        result = processor.process(b"Date;Description\n01.01.26;UNKNOWN STORE")
+        assert result["Payment"].iloc[0] == "direct"
+
+    def test_remap_multiple_columns(self, rules_bank_config, output_config):
+        """remap_values can target multiple columns in one config entry."""
+        rules_bank_config.remap_values = {
+            "Payment": {"joint": "to be split"},
+            "Payer": {"john": "alex"},
+        }
+        processor = CSVProcessor(rules_bank_config, output_config, "YYYY-MM-DD")
+        result = processor.process(b"Date;Description\n01.01.26;UNKNOWN STORE")
+        assert result["Payment"].iloc[0] == "to be split"
+        assert result["Payer"].iloc[0] == "alex"
+
+    def test_no_remap_values_key_no_change(
+        self, rules_bank_config, output_config
+    ):
+        """Without remap_values in bank config, all values stay as-is."""
+        # rules_bank_config has no remap_values key by default
+        processor = CSVProcessor(rules_bank_config, output_config, "YYYY-MM-DD")
+        result = processor.process(b"Date;Description\n01.01.26;UNKNOWN STORE")
+        assert result["Payment"].iloc[0] == "joint"
+
+    def test_nonexistent_column_is_ignored(
+        self, rules_bank_config, output_config
+    ):
+        """remap_values referencing a column absent from the output is silently skipped."""
+        rules_bank_config.remap_values = {
+            "NonExistent": {"joint": "to be split"}
+        }
+        processor = CSVProcessor(rules_bank_config, output_config, "YYYY-MM-DD")
+        # Should not raise
+        result = processor.process(b"Date;Description\n01.01.26;UNKNOWN STORE")
+        assert result["Payment"].iloc[0] == "joint"
+
+    def test_remap_applied_after_rules(
+        self, rules_bank_config, output_config, rules_config
+    ):
+        """remap_values fires after rules, so rule-set values are also remapped."""
+        # rent rule sets Payment to "direct" — remap should NOT touch it
+        # because "direct" != "joint"
+        rules_bank_config.remap_values = {"Payment": {"joint": "to be split"}}
+        processor = CSVProcessor(
+            rules_bank_config,
+            output_config,
+            "YYYY-MM-DD",
+            rules_config=rules_config,
+        )
+        result = processor.process(b"Date;Description\n01.01.26;MIETE JANUAR")
+        # rent rule sets Payment = "direct"; remap doesn't touch "direct"
+        assert result["Payment"].iloc[0] == "direct"
+
+    def test_all_rows_remapped(self, rules_bank_config, output_config):
+        """Every row with the old value is remapped, not just the first."""
+        rules_bank_config.remap_values = {"Payment": {"joint": "to be split"}}
+        processor = CSVProcessor(rules_bank_config, output_config, "YYYY-MM-DD")
+        csv = (
+            b"Date;Description\n"
+            b"01.01.26;STORE A\n"
+            b"02.01.26;STORE B\n"
+            b"03.01.26;STORE C"
+        )
+        result = processor.process(csv)
+        assert all(v == "to be split" for v in result["Payment"].tolist())


### PR DESCRIPTION
- Remapping rules and column definitions have been logically separated.
- Rules are processed from a general YAML with a more flexible config structure.
- Bank-specific rule overrides in bank configs are allowed (none by default).
- Specific unit tests have been added & pass.